### PR TITLE
Remove tclStubsPtr and tclPlatStubsPtr declarations from stubs.c

### DIFF
--- a/lib/critcl/critcl_c/stubs.c
+++ b/lib/critcl/critcl_c/stubs.c
@@ -1,9 +1,6 @@
-
 # line 1 "MyInitTclStubs"
 
 #if USE_TCL_STUBS
-  const TclStubs *tclStubsPtr;
-  const TclPlatStubs *tclPlatStubsPtr;
   const struct TclIntStubs *tclIntStubsPtr;
   const struct TclIntPlatStubs *tclIntPlatStubsPtr;
 


### PR DESCRIPTION
Those two seem to be already declared in Tcl headers we include here anyway;
however, if we build against system-provided headers of a different version,
they may or may not have 'const' declaration, so the compilation may fail.
