### PR TITLE
Load tsources with ::source instead of ::critcl::source.

### DIFF
--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -4217,7 +4217,7 @@ proc ::critcl::Load {f} {
     # 'compile & run' we now source the companion files directly.
     foreach t $tsrc {
 	Ignore $t
-	source $t
+	::source $t
     }
     return
 }


### PR DESCRIPTION
I ran into an "Illegal attempt to define C code in...after it was built" error with a critcl package I've just started writing. Couldn't understand why, at first. Here's a simple script to reproduce it (my system has critcl 3.1.11):

``` tcl
package require critcl
critcl::clean_cache
critcl::tsources dummy.tcl
critcl::cproc do_nothing {} void {}
do_nothing
```

(Note: dummy.tcl can be any Tcl script.)

The stack trace pointed me to the line changed in this pull request. Looks like this should have been changed when ::critcl::source was added.

P.S. Critcl is awesome!
