### PR TITLE
main.tcl: allow direct invoke (without starkit), so sourced/debug/dev-edition (uninstalled)

### DIFF
--- a/main.tcl
+++ b/main.tcl
@@ -1,5 +1,12 @@
-package require starkit
-if {[starkit::startup] == "sourced"} return
+if {![catch {
+  # kit related main:
+  package require starkit
+}]} {
+  if {[starkit::startup] == "sourced"} return
+} else {
+  # direct invoke without kit (sourced/debug/dev-edition):
+  lappend ::auto_path [file join [file dirname [info script]] lib]
+}
 package require critcl::app 3
 #puts [package ifneeded critcl [package require critcl::app 3]]
 critcl::app::main $argv


### PR DESCRIPTION
**interim artificial PR** to follow Roy's issue to build `tcllib` via `sak`.

I don't use starkit (may be it was an issue?) and don't have critcl executable, so I modified main of critcl (as in this PR) to build `tcllib` from `sak` using direct invocation from tclsh.

My test builds looks like:
```bash
cd /Projects/tcl/tcllib/
CC=gcc CRITCL=/Projects/tcl/critcl/main.tcl ./sak.tcl critcl
```
tested using gcc 7.3 (as well as 8.1) for x86 and x64.
It has produced a lot of warnings but no FAILED messages and has created a library successfully.

Duration: ca. 10 seconds on my machine.

@rkeene: could you test that this way?

@andreas-kupries: 
- can starkit or something in critcl executable cause this strange delay?
- although the PR is artificial, it'd be nice it you would merge it even as fallback for sourced builds like here.
  Of course it could be another file, like direct.tcl with some content like:
```tcl
lappend ::auto_path [file join [file dirname [info script]] lib]
package require critcl::app 3
critcl::app::main $argv
```