### PR TITLE
Possible fix for #103.

### DIFF
--- a/examples/queue/build.tcl
+++ b/examples/queue/build.tcl
@@ -129,6 +129,14 @@ proc _install {{ldir {}}} {
     file mkdir $ldir
 
     package require critcl::app
+    package require critcl
+    package require critcl::class
+
+    puts v=[set v  [package present critcl]]
+    puts [package ifneeded critcl        $v]
+
+    puts v=[set vc [package present critcl::class]]
+    puts [package ifneeded critcl::class $vc]
 
     foreach p $packages {
 	puts ""

--- a/examples/queue/cr.tcl
+++ b/examples/queue/cr.tcl
@@ -5,6 +5,10 @@
 
 cd [file dirname [file normalize [info script]]]
 source ../../lib/critcl/critcl.tcl
+source ../../lib/critcl-class/class.tcl
+
+puts v=[package present critcl]
+puts v=[package present critcl::class]
 
 # Show the config
 puts ""

--- a/examples/queue/cr.tcl
+++ b/examples/queue/cr.tcl
@@ -7,8 +7,11 @@ cd [file dirname [file normalize [info script]]]
 source ../../lib/critcl/critcl.tcl
 source ../../lib/critcl-class/class.tcl
 
-puts v=[package present critcl]
-puts v=[package present critcl::class]
+puts v=[set v [package present critcl]]
+puts [package ifneeded critcl $v]
+
+puts v=[set vc [package present critcl::class]]
+puts [package ifneeded critcl::class $vc]
 
 # Show the config
 puts ""

--- a/examples/queue/queuec.tcl
+++ b/examples/queue/queuec.tcl
@@ -5,7 +5,7 @@
 #       [x] Pure Tcl Implementation.
 #
 # Mainly demonstrates the utility package for the creation of classes
-# and objects in C, with both claaes and their instances represented
+# and objects in C, with both classes and their instances represented
 # as Tcl commands. In contrast to the stackc demo this does not use a
 # separate data structure package, nor separately written method
 # implementations.
@@ -50,7 +50,7 @@ critcl::class::define ::queuec {
 
     constructor {
 	if (objc > 0) {
-	    Tcl_AppendResult (interp, "wrong\#args for constructor, expected none", NULL);
+	    Tcl_AppendResult (interp, "wrong#args for constructor, expected none", NULL);
 	    goto error;
 	}
     }

--- a/lib/critcl-class/class.tcl
+++ b/lib/critcl-class/class.tcl
@@ -174,6 +174,7 @@ proc ::critcl::class::ProcessFlags {} {
     }
 
     dict set state buildflags [join $flags {, }]
+    critcl::msg "\n\tClass flags:     $flags"
     return
 }
 
@@ -485,7 +486,7 @@ proc ::critcl::class::MakeMap {} {
 proc ::critcl::class::Template {path} {
     variable selfdir
     set path $selfdir/$path
-    #puts T=$path
+    critcl::msg "\tClass templates: $path"
     return [critcl::util::Get $path]
 }
 
@@ -511,6 +512,7 @@ proc ::critcl::class::CAPIPrefix {name} {
 }
 
 proc ::critcl::class::Flag {key flag} {
+    critcl::msg " ($key = $flag)"
     variable state
     dict set state $key $flag
     return

--- a/lib/critcl-class/class.tcl
+++ b/lib/critcl-class/class.tcl
@@ -7,7 +7,7 @@
 # class made easy, with code for object command and method dispatch
 # generated.
 
-package provide critcl::class 1.1
+package provide critcl::class 1.1.1
 
 # # ## ### ##### ######## ############# #####################
 ## Requirements.
@@ -366,7 +366,7 @@ proc ::critcl::class::ProcessMethods {key} {
 	incr maxn 3
 
 	foreach name [lsort -dict [dict get $state $key names]] {
-	    set enum                    [dict get $state $key def $name enum]
+	    set enum   [string map $map [dict get $state $key def $name enum]]
 	    set case   [string map $map [dict get $state $key def $name case]]
 	    set code   [string map $map [dict get $state $key def $name code]]
 	    set syntax [string map $map [dict get $state $key def $name syntax]]

--- a/lib/critcl-class/class.tcl
+++ b/lib/critcl-class/class.tcl
@@ -487,7 +487,19 @@ proc ::critcl::class::Template {path} {
     variable selfdir
     set path $selfdir/$path
     critcl::msg "\tClass templates: $path"
-    return [critcl::util::Get $path]
+    return [Get $path]
+}
+
+proc ::critcl::class::Get {path} {
+    if {[catch {
+	set c [open $path r]
+	fconfigure $c -eofchar {}
+	set d [read $c]
+	close $c
+    }]} {
+	set d {}
+    }
+    return $d
 }
 
 proc ::critcl::class::Dedent {pfx text} {

--- a/lib/critcl-class/pkgIndex.tcl
+++ b/lib/critcl-class/pkgIndex.tcl
@@ -1,1 +1,1 @@
-package ifneeded critcl::class 1.1 [list source [file join $dir class.tcl]]
+package ifneeded critcl::class 1.1.1 [list source [file join $dir class.tcl]]


### PR DESCRIPTION
enum case contained @stem@ placeholder.
Not substituted it went into the generated code,
causing compilers to choke in the @ character.

+ Typo fix in example, and changed bad \# to single #.
+ Example compile&run mode changed to load packages from checkout.