### PR TITLE
Ignore more compilers

### DIFF
--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -2754,7 +2754,7 @@ proc ::critcl::setconfig {targetconfig} {
     # as well.
 
     set v::targetplatform $targetconfig
-    foreach p {gcc cc_r xlc xlc_r cc cl} {
+    foreach p {gcc cc_r xlc xlc_r cc cl clang([[:digit:]])*} {
 	if {[regsub -- "-$p\$" $v::targetplatform {} v::targetplatform]} break
     }
 


### PR DESCRIPTION
On FreeBSD, we support installing different versions of clang alonside,
in which case the compiler is called, e.g., clang90. This makes sure we
ignore that in the target platform definition.