### PR TITLE
Allow overriding critcl's home directory with an env variable

### DIFF
--- a/lib/app-critcl/critcl.tcl
+++ b/lib/app-critcl/critcl.tcl
@@ -174,7 +174,8 @@ proc ::critcl::app::PackageCache {} {
     if {$v::cache ne {}} {
 	return $v::cache
     }
-    return [file join ~ .critcl pkg[pid].[clock seconds]]
+    set home [expr {[info exists ::env(CRITCL_HOME)] ? $::env(CRITCL_HOME) : {~}}]
+    return [file join $home .critcl pkg[pid].[clock seconds]]
 }
 
 proc ::critcl::app::StopOnFailed {} {


### PR DESCRIPTION
This is useful when building in a chroot'd environment that doesn't have
access to the outside world, under a username that doesn't have a home
(e.g., the `nobody` username).

This patch was necessary for building "as-user" in FreeBSD's CI:
http://package19.nyi.freebsd.org/data/121amd64-default-build-as-user/533215/logs/errors/critcl-3.1.18.1.log

See critcl trying to create the /nonexistent directory.