### PR TITLE
Fixes #112. Performance bug for compile & run mode

### DIFF
--- a/doc/include/changes31.inc
+++ b/doc/include/changes31.inc
@@ -1,3 +1,4 @@
+[include changes31182.inc]
 [include changes31181.inc]
 [include changes3118.inc]
 [include changes3117.inc]

--- a/doc/include/changes31182.inc
+++ b/doc/include/changes31182.inc
@@ -1,0 +1,21 @@
+[section {Changes for version 3.1.18.2}]
+
+[strong {Not Released Yet}]
+
+[list_begin enumerated]
+
+[enum] [strong {Performance Fix}] for [term {compile & run}] mode.
+       Issue #112.
+
+[para] Moved the command activating more precise code location
+       tracking out of package [package critcl] into package
+       [package critcl::app].
+
+[para] The ahead of time compilation of the [term package] mode done
+       by the application (package) can bear the performance penalty
+       invoked by this [strong global] setting.
+
+[para] Arbitrary libraries and applications using critcl dynamically,
+       i.e. in [term {compile & run}] likely cannot, and should not.
+
+[list_end]

--- a/doc/include/changes31182.inc
+++ b/doc/include/changes31182.inc
@@ -11,11 +11,11 @@
        tracking out of package [package critcl] into package
        [package critcl::app].
 
-[para] The ahead of time compilation of the [term package] mode done
-       by the application (package) can bear the performance penalty
-       invoked by this [strong global] setting.
+[para] Because generating packages ahead of time can bear the
+       performance penalty invoked by this [strong global] setting.
 
-[para] Arbitrary libraries and applications using critcl dynamically,
-       i.e. in [term {compile & run}] likely cannot, and should not.
+[para] Arbitrary libraries and applications using critcl dynamically
+       ([term {compile & run}]) on the other hand likely cannot, and
+       should not.
 
 [list_end]

--- a/doc/pkg_version.inc
+++ b/doc/pkg_version.inc
@@ -1,1 +1,1 @@
-[vset VERSION 3.1.18]
+[vset VERSION 3.1.18.2]

--- a/embedded/man/files/changes.n
+++ b/embedded/man/files/changes.n
@@ -296,12 +296,12 @@ Moved the command activating more precise code location
 tracking out of package \fBcritcl\fR into package
 \fBcritcl::app\fR\&.
 .sp
-The ahead of time compilation of the \fIpackage\fR mode done
-by the application (package) can bear the performance penalty
-invoked by this \fIglobal\fR setting\&.
+Because generating packages ahead of time can bear the
+performance penalty invoked by this \fIglobal\fR setting\&.
 .sp
-Arbitrary libraries and applications using critcl dynamically,
-i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+Arbitrary libraries and applications using critcl dynamically
+(\fIcompile & run\fR) on the other hand likely cannot, and
+should not\&.
 .PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]

--- a/embedded/man/files/changes.n
+++ b/embedded/man/files/changes.n
@@ -286,6 +286,23 @@ This document provides an overview of the changes \fBcritcl\fR
 underwent from version to version\&.
 .PP
 The latest changes are found at the top\&.
+.SH "CHANGES FOR VERSION 3\&.1\&.18\&.2"
+\fINot Released Yet\fR
+.IP [1]
+\fIPerformance Fix\fR for \fIcompile & run\fR mode\&.
+Issue #112\&.
+.sp
+Moved the command activating more precise code location
+tracking out of package \fBcritcl\fR into package
+\fBcritcl::app\fR\&.
+.sp
+The ahead of time compilation of the \fIpackage\fR mode done
+by the application (package) can bear the performance penalty
+invoked by this \fIglobal\fR setting\&.
+.sp
+Arbitrary libraries and applications using critcl dynamically,
+i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+.PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]
 \fIAttention\fR: While the overall version (of the bundle)

--- a/embedded/man/files/critcl_app.n
+++ b/embedded/man/files/critcl_app.n
@@ -4,7 +4,7 @@
 '\" Copyright (c) Steve Landers
 '\" Copyright (c) 2011-2018 Andreas Kupries
 '\"
-.TH "critcl_app" n 3\&.1\&.18 doc "C Runtime In Tcl (CriTcl)"
+.TH "critcl_app" n 3\&.1\&.18\&.2 doc "C Runtime In Tcl (CriTcl)"
 .\" The -*- nroff -*- definitions below are for supplemental macros used
 .\" in Tcl/Tk manual entries.
 .\"
@@ -680,6 +680,23 @@ targets\&. The result of such a merge would look like:
 .CE
 .PP
 The latest changes are found at the top\&.
+.SH "CHANGES FOR VERSION 3\&.1\&.18\&.2"
+\fINot Released Yet\fR
+.IP [1]
+\fIPerformance Fix\fR for \fIcompile & run\fR mode\&.
+Issue #112\&.
+.sp
+Moved the command activating more precise code location
+tracking out of package \fBcritcl\fR into package
+\fBcritcl::app\fR\&.
+.sp
+The ahead of time compilation of the \fIpackage\fR mode done
+by the application (package) can bear the performance penalty
+invoked by this \fIglobal\fR setting\&.
+.sp
+Arbitrary libraries and applications using critcl dynamically,
+i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+.PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]
 \fIAttention\fR: While the overall version (of the bundle)

--- a/embedded/man/files/critcl_app.n
+++ b/embedded/man/files/critcl_app.n
@@ -690,12 +690,12 @@ Moved the command activating more precise code location
 tracking out of package \fBcritcl\fR into package
 \fBcritcl::app\fR\&.
 .sp
-The ahead of time compilation of the \fIpackage\fR mode done
-by the application (package) can bear the performance penalty
-invoked by this \fIglobal\fR setting\&.
+Because generating packages ahead of time can bear the
+performance penalty invoked by this \fIglobal\fR setting\&.
 .sp
-Arbitrary libraries and applications using critcl dynamically,
-i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+Arbitrary libraries and applications using critcl dynamically
+(\fIcompile & run\fR) on the other hand likely cannot, and
+should not\&.
 .PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]

--- a/embedded/man/files/critcl_apppkg.n
+++ b/embedded/man/files/critcl_apppkg.n
@@ -743,12 +743,12 @@ Moved the command activating more precise code location
 tracking out of package \fBcritcl\fR into package
 \fBcritcl::app\fR\&.
 .sp
-The ahead of time compilation of the \fIpackage\fR mode done
-by the application (package) can bear the performance penalty
-invoked by this \fIglobal\fR setting\&.
+Because generating packages ahead of time can bear the
+performance penalty invoked by this \fIglobal\fR setting\&.
 .sp
-Arbitrary libraries and applications using critcl dynamically,
-i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+Arbitrary libraries and applications using critcl dynamically
+(\fIcompile & run\fR) on the other hand likely cannot, and
+should not\&.
 .PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]

--- a/embedded/man/files/critcl_apppkg.n
+++ b/embedded/man/files/critcl_apppkg.n
@@ -4,7 +4,7 @@
 '\" Copyright (c) Steve Landers
 '\" Copyright (c) 2011-2018 Andreas Kupries
 '\"
-.TH "critcl::app" n 3\&.1\&.18 doc "C Runtime In Tcl (CriTcl)"
+.TH "critcl::app" n 3\&.1\&.18\&.2 doc "C Runtime In Tcl (CriTcl)"
 .\" The -*- nroff -*- definitions below are for supplemental macros used
 .\" in Tcl/Tk manual entries.
 .\"
@@ -278,7 +278,7 @@ critcl::app \- CriTcl - Application Package Reference
 .SH SYNOPSIS
 package require \fBTcl  8\&.4\fR
 .sp
-package require \fBcritcl::app  ?3\&.1\&.18?\fR
+package require \fBcritcl::app  ?3\&.1\&.18\&.2?\fR
 .sp
 package require \fBcritcl  ?2?\fR
 .sp
@@ -733,6 +733,23 @@ targets\&. The result of such a merge would look like:
 .CE
 .PP
 The latest changes are found at the top\&.
+.SH "CHANGES FOR VERSION 3\&.1\&.18\&.2"
+\fINot Released Yet\fR
+.IP [1]
+\fIPerformance Fix\fR for \fIcompile & run\fR mode\&.
+Issue #112\&.
+.sp
+Moved the command activating more precise code location
+tracking out of package \fBcritcl\fR into package
+\fBcritcl::app\fR\&.
+.sp
+The ahead of time compilation of the \fIpackage\fR mode done
+by the application (package) can bear the performance penalty
+invoked by this \fIglobal\fR setting\&.
+.sp
+Arbitrary libraries and applications using critcl dynamically,
+i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+.PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]
 \fIAttention\fR: While the overall version (of the bundle)

--- a/embedded/man/files/critcl_cproc.n
+++ b/embedded/man/files/critcl_cproc.n
@@ -4,7 +4,7 @@
 '\" Copyright (c) Steve Landers
 '\" Copyright (c) 2011-2018 Andreas Kupries
 '\"
-.TH "critcl-cproc-types" n 3\&.1\&.18 doc "C Runtime In Tcl (CriTcl)"
+.TH "critcl-cproc-types" n 3\&.1\&.18\&.2 doc "C Runtime In Tcl (CriTcl)"
 .\" The -*- nroff -*- definitions below are for supplemental macros used
 .\" in Tcl/Tk manual entries.
 .\"
@@ -278,7 +278,7 @@ critcl-cproc-types \- CriTcl - cproc Type Reference
 .SH SYNOPSIS
 package require \fBTcl  8\&.4\fR
 .sp
-package require \fBcritcl  ?3\&.1\&.18?\fR
+package require \fBcritcl  ?3\&.1\&.18\&.2?\fR
 .sp
 \fB::critcl::has-resulttype\fR \fIname\fR
 .sp

--- a/embedded/man/files/critcl_introduction.n
+++ b/embedded/man/files/critcl_introduction.n
@@ -495,12 +495,12 @@ Moved the command activating more precise code location
 tracking out of package \fBcritcl\fR into package
 \fBcritcl::app\fR\&.
 .sp
-The ahead of time compilation of the \fIpackage\fR mode done
-by the application (package) can bear the performance penalty
-invoked by this \fIglobal\fR setting\&.
+Because generating packages ahead of time can bear the
+performance penalty invoked by this \fIglobal\fR setting\&.
 .sp
-Arbitrary libraries and applications using critcl dynamically,
-i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+Arbitrary libraries and applications using critcl dynamically
+(\fIcompile & run\fR) on the other hand likely cannot, and
+should not\&.
 .PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]

--- a/embedded/man/files/critcl_introduction.n
+++ b/embedded/man/files/critcl_introduction.n
@@ -485,6 +485,23 @@ overall picture shown by the large examples mentioned in the previous
 paragraph\&.
 .PP
 The latest changes are found at the top\&.
+.SH "CHANGES FOR VERSION 3\&.1\&.18\&.2"
+\fINot Released Yet\fR
+.IP [1]
+\fIPerformance Fix\fR for \fIcompile & run\fR mode\&.
+Issue #112\&.
+.sp
+Moved the command activating more precise code location
+tracking out of package \fBcritcl\fR into package
+\fBcritcl::app\fR\&.
+.sp
+The ahead of time compilation of the \fIpackage\fR mode done
+by the application (package) can bear the performance penalty
+invoked by this \fIglobal\fR setting\&.
+.sp
+Arbitrary libraries and applications using critcl dynamically,
+i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+.PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]
 \fIAttention\fR: While the overall version (of the bundle)

--- a/embedded/man/files/critcl_pkg.n
+++ b/embedded/man/files/critcl_pkg.n
@@ -3119,12 +3119,12 @@ Moved the command activating more precise code location
 tracking out of package \fBcritcl\fR into package
 \fBcritcl::app\fR\&.
 .sp
-The ahead of time compilation of the \fIpackage\fR mode done
-by the application (package) can bear the performance penalty
-invoked by this \fIglobal\fR setting\&.
+Because generating packages ahead of time can bear the
+performance penalty invoked by this \fIglobal\fR setting\&.
 .sp
-Arbitrary libraries and applications using critcl dynamically,
-i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+Arbitrary libraries and applications using critcl dynamically
+(\fIcompile & run\fR) on the other hand likely cannot, and
+should not\&.
 .PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]

--- a/embedded/man/files/critcl_pkg.n
+++ b/embedded/man/files/critcl_pkg.n
@@ -4,7 +4,7 @@
 '\" Copyright (c) Steve Landers
 '\" Copyright (c) 2011-2018 Andreas Kupries
 '\"
-.TH "critcl" n 3\&.1\&.18 doc "C Runtime In Tcl (CriTcl)"
+.TH "critcl" n 3\&.1\&.18\&.2 doc "C Runtime In Tcl (CriTcl)"
 .\" The -*- nroff -*- definitions below are for supplemental macros used
 .\" in Tcl/Tk manual entries.
 .\"
@@ -278,7 +278,7 @@ critcl \- CriTcl - Package Reference
 .SH SYNOPSIS
 package require \fBTcl  8\&.4\fR
 .sp
-package require \fBcritcl  ?3\&.1\&.18?\fR
+package require \fBcritcl  ?3\&.1\&.18\&.2?\fR
 .sp
 package require \fBplatform  ?1\&.0\&.2?\fR
 .sp
@@ -3109,6 +3109,23 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 See section "Embedding C" in \fIUsing CriTcl\fR\&.
 .PP
 The latest changes are found at the top\&.
+.SH "CHANGES FOR VERSION 3\&.1\&.18\&.2"
+\fINot Released Yet\fR
+.IP [1]
+\fIPerformance Fix\fR for \fIcompile & run\fR mode\&.
+Issue #112\&.
+.sp
+Moved the command activating more precise code location
+tracking out of package \fBcritcl\fR into package
+\fBcritcl::app\fR\&.
+.sp
+The ahead of time compilation of the \fIpackage\fR mode done
+by the application (package) can bear the performance penalty
+invoked by this \fIglobal\fR setting\&.
+.sp
+Arbitrary libraries and applications using critcl dynamically,
+i\&.e\&. in \fIcompile & run\fR likely cannot, and should not\&.
+.PP
 .SH "CHANGES FOR VERSION 3\&.1\&.18\&.1"
 .IP [1]
 \fIAttention\fR: While the overall version (of the bundle)

--- a/embedded/www/files/changes.html
+++ b/embedded/www/files/changes.html
@@ -110,37 +110,38 @@
 <ul class="doctools_toc">
 <li class="doctools_section"><a href="#toc">Table Of Contents</a></li>
 <li class="doctools_section"><a href="#section1">Description</a></li>
-<li class="doctools_section"><a href="#section2">Changes for version 3.1.18.1</a></li>
-<li class="doctools_section"><a href="#section3">Changes for version 3.1.18</a></li>
-<li class="doctools_section"><a href="#section4">Changes for version 3.1.17</a></li>
-<li class="doctools_section"><a href="#section5">Changes for version 3.1.16</a></li>
-<li class="doctools_section"><a href="#section6">Changes for version 3.1.15</a></li>
-<li class="doctools_section"><a href="#section7">Changes for version 3.1.14</a></li>
-<li class="doctools_section"><a href="#section8">Changes for version 3.1.13</a></li>
-<li class="doctools_section"><a href="#section9">Changes for version 3.1.12</a></li>
-<li class="doctools_section"><a href="#section10">Changes for version 3.1.11</a></li>
-<li class="doctools_section"><a href="#section11">Changes for version 3.1.10</a></li>
-<li class="doctools_section"><a href="#section12">Changes for version 3.1.9</a></li>
-<li class="doctools_section"><a href="#section13">Changes for version 3.1.8</a></li>
-<li class="doctools_section"><a href="#section14">Changes for version 3.1.7</a></li>
-<li class="doctools_section"><a href="#section15">Changes for version 3.1.6</a></li>
-<li class="doctools_section"><a href="#section16">Changes for version 3.1.5</a></li>
-<li class="doctools_section"><a href="#section17">Changes for version 3.1.4</a></li>
-<li class="doctools_section"><a href="#section18">Changes for version 3.1.3</a></li>
-<li class="doctools_section"><a href="#section19">Changes for version 3.1.2</a></li>
-<li class="doctools_section"><a href="#section20">Changes for version 3.1.1</a></li>
-<li class="doctools_section"><a href="#section21">Changes for version 3.1</a></li>
-<li class="doctools_section"><a href="#section22">Changes for version 3.0.7</a></li>
-<li class="doctools_section"><a href="#section23">Changes for version 3.0.6</a></li>
-<li class="doctools_section"><a href="#section24">Changes for version 3.0.5</a></li>
-<li class="doctools_section"><a href="#section25">Changes for version 3.0.4</a></li>
-<li class="doctools_section"><a href="#section26">Changes for version 3.0.3</a></li>
-<li class="doctools_section"><a href="#section27">Changes for version 3.0.2</a></li>
-<li class="doctools_section"><a href="#section28">Changes for version 3.0.1</a></li>
-<li class="doctools_section"><a href="#section29">Changes for version 3</a></li>
-<li class="doctools_section"><a href="#section30">Changes for version 2.1</a></li>
-<li class="doctools_section"><a href="#section31">Authors</a></li>
-<li class="doctools_section"><a href="#section32">Bugs, Ideas, Feedback</a></li>
+<li class="doctools_section"><a href="#section2">Changes for version 3.1.18.2</a></li>
+<li class="doctools_section"><a href="#section3">Changes for version 3.1.18.1</a></li>
+<li class="doctools_section"><a href="#section4">Changes for version 3.1.18</a></li>
+<li class="doctools_section"><a href="#section5">Changes for version 3.1.17</a></li>
+<li class="doctools_section"><a href="#section6">Changes for version 3.1.16</a></li>
+<li class="doctools_section"><a href="#section7">Changes for version 3.1.15</a></li>
+<li class="doctools_section"><a href="#section8">Changes for version 3.1.14</a></li>
+<li class="doctools_section"><a href="#section9">Changes for version 3.1.13</a></li>
+<li class="doctools_section"><a href="#section10">Changes for version 3.1.12</a></li>
+<li class="doctools_section"><a href="#section11">Changes for version 3.1.11</a></li>
+<li class="doctools_section"><a href="#section12">Changes for version 3.1.10</a></li>
+<li class="doctools_section"><a href="#section13">Changes for version 3.1.9</a></li>
+<li class="doctools_section"><a href="#section14">Changes for version 3.1.8</a></li>
+<li class="doctools_section"><a href="#section15">Changes for version 3.1.7</a></li>
+<li class="doctools_section"><a href="#section16">Changes for version 3.1.6</a></li>
+<li class="doctools_section"><a href="#section17">Changes for version 3.1.5</a></li>
+<li class="doctools_section"><a href="#section18">Changes for version 3.1.4</a></li>
+<li class="doctools_section"><a href="#section19">Changes for version 3.1.3</a></li>
+<li class="doctools_section"><a href="#section20">Changes for version 3.1.2</a></li>
+<li class="doctools_section"><a href="#section21">Changes for version 3.1.1</a></li>
+<li class="doctools_section"><a href="#section22">Changes for version 3.1</a></li>
+<li class="doctools_section"><a href="#section23">Changes for version 3.0.7</a></li>
+<li class="doctools_section"><a href="#section24">Changes for version 3.0.6</a></li>
+<li class="doctools_section"><a href="#section25">Changes for version 3.0.5</a></li>
+<li class="doctools_section"><a href="#section26">Changes for version 3.0.4</a></li>
+<li class="doctools_section"><a href="#section27">Changes for version 3.0.3</a></li>
+<li class="doctools_section"><a href="#section28">Changes for version 3.0.2</a></li>
+<li class="doctools_section"><a href="#section29">Changes for version 3.0.1</a></li>
+<li class="doctools_section"><a href="#section30">Changes for version 3</a></li>
+<li class="doctools_section"><a href="#section31">Changes for version 2.1</a></li>
+<li class="doctools_section"><a href="#section32">Authors</a></li>
+<li class="doctools_section"><a href="#section33">Bugs, Ideas, Feedback</a></li>
 <li class="doctools_section"><a href="#keywords">Keywords</a></li>
 <li class="doctools_section"><a href="#category">Category</a></li>
 <li class="doctools_section"><a href="#copyright">Copyright</a></li>
@@ -155,7 +156,22 @@ performance by rewriting in C those routines that are performance bottlenecks.</
 underwent from version to version.</p>
 <p>The latest changes are found at the top.</p>
 </div>
-<div id="section2" class="doctools_section"><h2><a name="section2">Changes for version 3.1.18.1</a></h2>
+<div id="section2" class="doctools_section"><h2><a name="section2">Changes for version 3.1.18.2</a></h2>
+<p><em>Not Released Yet</em></p>
+<ol class="doctools_enumerated">
+<li><p><em>Performance Fix</em> for <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> mode.
+       Issue #112.</p>
+<p>Moved the command activating more precise code location
+       tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
+       <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
+<p>The ahead of time compilation of the <i class="term">package</i> mode done
+       by the application (package) can bear the performance penalty
+       invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically,
+       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+</ol>
+</div>
+<div id="section3" class="doctools_section"><h2><a name="section3">Changes for version 3.1.18.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p><em>Attention</em>: While the overall version (of the bundle)
        moves to 3.1.18.1 the versions of packages <b class="package"><a href="critcl_pkg.html">critcl</a></b> and
@@ -168,7 +184,7 @@ underwent from version to version.</p>
        compilation of the generated code.</p></li>
 </ol>
 </div>
-<div id="section3" class="doctools_section"><h2><a name="section3">Changes for version 3.1.18</a></h2>
+<div id="section4" class="doctools_section"><h2><a name="section4">Changes for version 3.1.18</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Feature (Developer support). Merged pull request #96 from
        sebres/main-direct-invoke. Enables direct invokation of the
@@ -246,7 +262,7 @@ underwent from version to version.</p>
 <p>See the package reference for the details.</p></li>
 </ol>
 </div>
-<div id="section4" class="doctools_section"><h2><a name="section4">Changes for version 3.1.17</a></h2>
+<div id="section5" class="doctools_section"><h2><a name="section5">Changes for version 3.1.17</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Extension: Allow duplicate arg- and result-type definitions if
        they are fully identical.</p></li>
@@ -298,7 +314,7 @@ underwent from version to version.</p>
        default. Both modes can be used together.</p></li>
 </ol>
 </div>
-<div id="section5" class="doctools_section"><h2><a name="section5">Changes for version 3.1.16</a></h2>
+<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.16</a></h2>
 <ol class="doctools_enumerated">
 <li><p>New feature. Extended <b class="cmd">critcl::cproc</b>'s argument handling
        to allow arbitrary mixing of required and optional arguments.</p></li>
@@ -344,12 +360,12 @@ underwent from version to version.</p>
        is limited to mode <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>.</p></li>
 </ol>
 </div>
-<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.15</a></h2>
+<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.15</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed version number bogosity with <b class="const">3.1.14</b>.</p></li>
 </ol>
 </div>
-<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.14</a></h2>
+<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.14</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #36. Added message to target <b class="const">all</b> of the
         Makefile generated for TEA mode. Additionally tweaked other
@@ -379,7 +395,7 @@ underwent from version to version.</p>
         location of the troubling declaration.</p></li>
 </ol>
 </div>
-<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.13</a></h2>
+<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.13</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Merged PR #43. Fixed bug loading adjunct Tcl sources.</p></li>
 <li><p>Fixes in documentation and generated code of package
@@ -430,7 +446,7 @@ underwent from version to version.</p>
 	a fix as they are all built on top of &quot;iassoc&quot;.</p></li>
 </ol>
 </div>
-<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.12</a></h2>
+<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.12</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue 42. Clear ::errorInfo immediately after startup to
        prevent leakage of irrelevant (caught) errors into our script
@@ -455,7 +471,7 @@ underwent from version to version.</p>
 	<b class="package"><a href="critcl_enum.html">critcl::enum</a></b></p></li>
 </ol>
 </div>
-<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.11</a></h2>
+<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.11</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #37, via pull request #38, with thanks to
        Jos DeCoster. Information was stored into the v::delproc
@@ -475,7 +491,7 @@ underwent from version to version.</p>
        Built on top of <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p></li>
 </ol>
 </div>
-<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.10</a></h2>
+<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.10</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed code version numbering forgotten with 3.1.9.</p></li>
 <li><p>Fixed issue #35. In package mode (-pkg) the object cache
@@ -491,7 +507,7 @@ underwent from version to version.</p>
 	sources. Bug and fix reported by Peter Spjuth.</p></li>
 </ol>
 </div>
-<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.9</a></h2>
+<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.9</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #27. Added missing platform definitions for
 	various alternate linux and OS X targets.</p></li>
@@ -515,7 +531,7 @@ underwent from version to version.</p>
 <li><p>Fixed issue #34. Handle files starting with a dot better.</p></li>
 </ol>
 </div>
-<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.8</a></h2>
+<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.8</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue with package indices generated for Tcl 8.4.
 	Join the list of commands with semi-colon, not newline.</p></li>
@@ -523,7 +539,7 @@ underwent from version to version.</p>
 	consider while fixing bug #21 (see critcl 3.1.6).</p></li>
 </ol>
 </div>
-<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.7</a></h2>
+<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #24. Extract and unconditionally display compiler
 	warnings found in the build log. Prevents users from missing
@@ -536,7 +552,7 @@ underwent from version to version.</p>
 	inherit values from configurations defined before them.</p></li>
 </ol>
 </div>
-<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.6</a></h2>
+<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #21. While the multi-definition of the stub-table
        pointer variables was ok with for all the C linkers seen so far
@@ -558,7 +574,7 @@ underwent from version to version.</p>
 <li><p>Fixed issue #23.</p></li>
 </ol>
 </div>
-<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.5</a></h2>
+<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #19. Made the regular expression extracting the
        MSVC version number more general to make it work on german
@@ -568,7 +584,7 @@ underwent from version to version.</p>
        a unix emulation environment like msys/mingw.</p></li>
 </ol>
 </div>
-<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.4</a></h2>
+<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfix in package <b class="package"><a href="critcl_class.html">critcl::class</a></b>. Generate a dummy
        field in the class structure if the class has no class
@@ -579,7 +595,7 @@ underwent from version to version.</p>
        <b class="cmd"><a href="critcl_class.html">critcl::class</a></b>.</p></li>
 </ol>
 </div>
-<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.3</a></h2>
+<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Added new argument type &quot;pstring&quot;, for &quot;Pascal String&quot;, a
@@ -595,7 +611,7 @@ underwent from version to version.</p>
        Versions bumped to 1.0.4 and 1.0.1 respectively.</p></li>
 </ol>
 </div>
-<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.2</a></h2>
+<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Extended <b class="cmd">critcl::cproc</b> to be able to handle optional
@@ -606,7 +622,7 @@ underwent from version to version.</p>
        emulation package <b class="package">lassign84</b> to 1.0.1.</p></li>
 </ol>
 </div>
-<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.1</a></h2>
+<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed the generation of wrong#args errors for
@@ -620,7 +636,7 @@ separators. Bumped to version 1.0.1.</p></li>
 instance creation for clarity. Bumped to version 1.0.2.</p></li>
 </ol>
 </div>
-<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1</a></h2>
+<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Added a new higher-level package <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p>
 <p>This package simplifies the creation of code associating data
@@ -679,7 +695,7 @@ define custom argument and result types for <b class="cmd">::critcl::cproc</b>.<
 details of the provided commands.</p></li>
 </ol>
 </div>
-<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.0.7</a></h2>
+<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.0.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed the code generated by <b class="cmd">critcl::c++command</b>.
         The emitted code handed a non-static string table to
@@ -689,7 +705,7 @@ details of the provided commands.</p></li>
 	us to the general problem.</p></li>
 </ol>
 </div>
-<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.0.6</a></h2>
+<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.0.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issue 10. The critcl application now delivers a
 	proper exit code (1) on build failure, instead of always
@@ -702,7 +718,7 @@ details of the provided commands.</p></li>
 	the README.md shown by github</p></li>
 </ol>
 </div>
-<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.0.5</a></h2>
+<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.0.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug in the new code for #line pragmas triggered when
 	specifying C code without leading whitespace.</p></li>
@@ -710,7 +726,7 @@ details of the provided commands.</p></li>
 	source retrieval, installer, and developer's guides.</p></li>
 </ol>
 </div>
-<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.0.4</a></h2>
+<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.0.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed generation of the package's initname when the incoming
 	code is read from stdin and has no proper path.</p></li>
@@ -740,7 +756,7 @@ details of the provided commands.</p></li>
 	release.</p></li>
 </ol>
 </div>
-<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.0.3</a></h2>
+<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issues 5 and 8, for the example build.tcl
 scripts. Working around a missing variable ::errorInfo. It should
@@ -748,7 +764,7 @@ always be present, however there seem to be revisions of Tcl around
 which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.2</a></h2>
+<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue in compile-and-run mode where commands put into the
 auto_index are not found by Tcl's [unknown] command.</p></li>
@@ -761,7 +777,7 @@ option <b class="option">-I</b>, just for library search paths.</p></li>
 revisions of Tcl around which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.1</a></h2>
+<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.0.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed recording of Tcl version requirements. Keep package name
@@ -792,7 +808,7 @@ for the library in the paths specified by the environment variable
 LIB.</p></li>
 </ol>
 </div>
-<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3</a></h2>
+<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>The command <b class="cmd">critcl::platform</b> was deprecated in version
 2.1, superceded by <b class="cmd">critcl::targetplatform</b>, yet kept for
@@ -859,7 +875,7 @@ for/about the package.</p>
 <b class="package"><a href="critcl_pkg.html">critcl</a></b> package documentation for details.</p></li>
 </ol>
 </div>
-<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 2.1</a></h2>
+<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 2.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug where <b class="cmd">critcl::tsources</b> interpreted relative
 paths as relative to the current working directory instead of
@@ -956,10 +972,10 @@ still using proper path names and init function.</p></li>
 <li><p>Dropped remnants of support for Tcl 8.3 and before.</p></li>
 </ol>
 </div>
-<div id="section31" class="doctools_section"><h2><a name="section31">Authors</a></h2>
+<div id="section32" class="doctools_section"><h2><a name="section32">Authors</a></h2>
 <p>Jean Claude Wippler, Steve Landers, Andreas Kupries</p>
 </div>
-<div id="section32" class="doctools_section"><h2><a name="section32">Bugs, Ideas, Feedback</a></h2>
+<div id="section33" class="doctools_section"><h2><a name="section33">Bugs, Ideas, Feedback</a></h2>
 <p>This document, and the package it describes, will undoubtedly contain
 bugs and other problems.
 Please report them at <a href="https://github.com/andreas-kupries/critcl/issues">https://github.com/andreas-kupries/critcl/issues</a>.

--- a/embedded/www/files/changes.html
+++ b/embedded/www/files/changes.html
@@ -164,11 +164,11 @@ underwent from version to version.</p>
 <p>Moved the command activating more precise code location
        tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
        <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
-<p>The ahead of time compilation of the <i class="term">package</i> mode done
-       by the application (package) can bear the performance penalty
-       invoked by this <em>global</em> setting.</p>
-<p>Arbitrary libraries and applications using critcl dynamically,
-       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+<p>Because generating packages ahead of time can bear the
+       performance penalty invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically
+       (<i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>) on the other hand likely cannot, and
+       should not.</p></li>
 </ol>
 </div>
 <div id="section3" class="doctools_section"><h2><a name="section3">Changes for version 3.1.18.1</a></h2>

--- a/embedded/www/files/critcl_app.html
+++ b/embedded/www/files/critcl_app.html
@@ -102,7 +102,7 @@
 &#124; <a href="../index.html">Keyword Index</a>
  ] <hr>
 <div class="doctools">
-<h1 class="doctools_title">critcl_app(n) 3.1.18 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
+<h1 class="doctools_title">critcl_app(n) 3.1.18.2 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
 <div id="name" class="doctools_section"><h2><a name="name">Name</a></h2>
 <p>critcl_app - CriTcl - Application</p>
 </div>
@@ -113,37 +113,38 @@
 <li class="doctools_section"><a href="#section1">Description</a></li>
 <li class="doctools_section"><a href="#section2">Application Options</a></li>
 <li class="doctools_section"><a href="#section3">Package Structure</a></li>
-<li class="doctools_section"><a href="#section4">Changes for version 3.1.18.1</a></li>
-<li class="doctools_section"><a href="#section5">Changes for version 3.1.18</a></li>
-<li class="doctools_section"><a href="#section6">Changes for version 3.1.17</a></li>
-<li class="doctools_section"><a href="#section7">Changes for version 3.1.16</a></li>
-<li class="doctools_section"><a href="#section8">Changes for version 3.1.15</a></li>
-<li class="doctools_section"><a href="#section9">Changes for version 3.1.14</a></li>
-<li class="doctools_section"><a href="#section10">Changes for version 3.1.13</a></li>
-<li class="doctools_section"><a href="#section11">Changes for version 3.1.12</a></li>
-<li class="doctools_section"><a href="#section12">Changes for version 3.1.11</a></li>
-<li class="doctools_section"><a href="#section13">Changes for version 3.1.10</a></li>
-<li class="doctools_section"><a href="#section14">Changes for version 3.1.9</a></li>
-<li class="doctools_section"><a href="#section15">Changes for version 3.1.8</a></li>
-<li class="doctools_section"><a href="#section16">Changes for version 3.1.7</a></li>
-<li class="doctools_section"><a href="#section17">Changes for version 3.1.6</a></li>
-<li class="doctools_section"><a href="#section18">Changes for version 3.1.5</a></li>
-<li class="doctools_section"><a href="#section19">Changes for version 3.1.4</a></li>
-<li class="doctools_section"><a href="#section20">Changes for version 3.1.3</a></li>
-<li class="doctools_section"><a href="#section21">Changes for version 3.1.2</a></li>
-<li class="doctools_section"><a href="#section22">Changes for version 3.1.1</a></li>
-<li class="doctools_section"><a href="#section23">Changes for version 3.1</a></li>
-<li class="doctools_section"><a href="#section24">Changes for version 3.0.7</a></li>
-<li class="doctools_section"><a href="#section25">Changes for version 3.0.6</a></li>
-<li class="doctools_section"><a href="#section26">Changes for version 3.0.5</a></li>
-<li class="doctools_section"><a href="#section27">Changes for version 3.0.4</a></li>
-<li class="doctools_section"><a href="#section28">Changes for version 3.0.3</a></li>
-<li class="doctools_section"><a href="#section29">Changes for version 3.0.2</a></li>
-<li class="doctools_section"><a href="#section30">Changes for version 3.0.1</a></li>
-<li class="doctools_section"><a href="#section31">Changes for version 3</a></li>
-<li class="doctools_section"><a href="#section32">Changes for version 2.1</a></li>
-<li class="doctools_section"><a href="#section33">Authors</a></li>
-<li class="doctools_section"><a href="#section34">Bugs, Ideas, Feedback</a></li>
+<li class="doctools_section"><a href="#section4">Changes for version 3.1.18.2</a></li>
+<li class="doctools_section"><a href="#section5">Changes for version 3.1.18.1</a></li>
+<li class="doctools_section"><a href="#section6">Changes for version 3.1.18</a></li>
+<li class="doctools_section"><a href="#section7">Changes for version 3.1.17</a></li>
+<li class="doctools_section"><a href="#section8">Changes for version 3.1.16</a></li>
+<li class="doctools_section"><a href="#section9">Changes for version 3.1.15</a></li>
+<li class="doctools_section"><a href="#section10">Changes for version 3.1.14</a></li>
+<li class="doctools_section"><a href="#section11">Changes for version 3.1.13</a></li>
+<li class="doctools_section"><a href="#section12">Changes for version 3.1.12</a></li>
+<li class="doctools_section"><a href="#section13">Changes for version 3.1.11</a></li>
+<li class="doctools_section"><a href="#section14">Changes for version 3.1.10</a></li>
+<li class="doctools_section"><a href="#section15">Changes for version 3.1.9</a></li>
+<li class="doctools_section"><a href="#section16">Changes for version 3.1.8</a></li>
+<li class="doctools_section"><a href="#section17">Changes for version 3.1.7</a></li>
+<li class="doctools_section"><a href="#section18">Changes for version 3.1.6</a></li>
+<li class="doctools_section"><a href="#section19">Changes for version 3.1.5</a></li>
+<li class="doctools_section"><a href="#section20">Changes for version 3.1.4</a></li>
+<li class="doctools_section"><a href="#section21">Changes for version 3.1.3</a></li>
+<li class="doctools_section"><a href="#section22">Changes for version 3.1.2</a></li>
+<li class="doctools_section"><a href="#section23">Changes for version 3.1.1</a></li>
+<li class="doctools_section"><a href="#section24">Changes for version 3.1</a></li>
+<li class="doctools_section"><a href="#section25">Changes for version 3.0.7</a></li>
+<li class="doctools_section"><a href="#section26">Changes for version 3.0.6</a></li>
+<li class="doctools_section"><a href="#section27">Changes for version 3.0.5</a></li>
+<li class="doctools_section"><a href="#section28">Changes for version 3.0.4</a></li>
+<li class="doctools_section"><a href="#section29">Changes for version 3.0.3</a></li>
+<li class="doctools_section"><a href="#section30">Changes for version 3.0.2</a></li>
+<li class="doctools_section"><a href="#section31">Changes for version 3.0.1</a></li>
+<li class="doctools_section"><a href="#section32">Changes for version 3</a></li>
+<li class="doctools_section"><a href="#section33">Changes for version 2.1</a></li>
+<li class="doctools_section"><a href="#section34">Authors</a></li>
+<li class="doctools_section"><a href="#section35">Bugs, Ideas, Feedback</a></li>
 <li class="doctools_section"><a href="#keywords">Keywords</a></li>
 <li class="doctools_section"><a href="#category">Category</a></li>
 <li class="doctools_section"><a href="#copyright">Copyright</a></li>
@@ -441,7 +442,22 @@ targets. The result of such a merge would look like:</p>
 </pre>
 <p>The latest changes are found at the top.</p>
 </div>
-<div id="section4" class="doctools_section"><h2><a name="section4">Changes for version 3.1.18.1</a></h2>
+<div id="section4" class="doctools_section"><h2><a name="section4">Changes for version 3.1.18.2</a></h2>
+<p><em>Not Released Yet</em></p>
+<ol class="doctools_enumerated">
+<li><p><em>Performance Fix</em> for <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> mode.
+       Issue #112.</p>
+<p>Moved the command activating more precise code location
+       tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
+       <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
+<p>The ahead of time compilation of the <i class="term">package</i> mode done
+       by the application (package) can bear the performance penalty
+       invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically,
+       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+</ol>
+</div>
+<div id="section5" class="doctools_section"><h2><a name="section5">Changes for version 3.1.18.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p><em>Attention</em>: While the overall version (of the bundle)
        moves to 3.1.18.1 the versions of packages <b class="package"><a href="critcl_pkg.html">critcl</a></b> and
@@ -454,7 +470,7 @@ targets. The result of such a merge would look like:</p>
        compilation of the generated code.</p></li>
 </ol>
 </div>
-<div id="section5" class="doctools_section"><h2><a name="section5">Changes for version 3.1.18</a></h2>
+<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.18</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Feature (Developer support). Merged pull request #96 from
        sebres/main-direct-invoke. Enables direct invokation of the
@@ -532,7 +548,7 @@ targets. The result of such a merge would look like:</p>
 <p>See the package reference for the details.</p></li>
 </ol>
 </div>
-<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.17</a></h2>
+<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.17</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Extension: Allow duplicate arg- and result-type definitions if
        they are fully identical.</p></li>
@@ -584,7 +600,7 @@ targets. The result of such a merge would look like:</p>
        default. Both modes can be used together.</p></li>
 </ol>
 </div>
-<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.16</a></h2>
+<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.16</a></h2>
 <ol class="doctools_enumerated">
 <li><p>New feature. Extended <b class="cmd">critcl::cproc</b>'s argument handling
        to allow arbitrary mixing of required and optional arguments.</p></li>
@@ -630,12 +646,12 @@ targets. The result of such a merge would look like:</p>
        is limited to mode <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>.</p></li>
 </ol>
 </div>
-<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.15</a></h2>
+<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.15</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed version number bogosity with <b class="const">3.1.14</b>.</p></li>
 </ol>
 </div>
-<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.14</a></h2>
+<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.14</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #36. Added message to target <b class="const">all</b> of the
         Makefile generated for TEA mode. Additionally tweaked other
@@ -665,7 +681,7 @@ targets. The result of such a merge would look like:</p>
         location of the troubling declaration.</p></li>
 </ol>
 </div>
-<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.13</a></h2>
+<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.13</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Merged PR #43. Fixed bug loading adjunct Tcl sources.</p></li>
 <li><p>Fixes in documentation and generated code of package
@@ -716,7 +732,7 @@ targets. The result of such a merge would look like:</p>
 	a fix as they are all built on top of &quot;iassoc&quot;.</p></li>
 </ol>
 </div>
-<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.12</a></h2>
+<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.12</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue 42. Clear ::errorInfo immediately after startup to
        prevent leakage of irrelevant (caught) errors into our script
@@ -741,7 +757,7 @@ targets. The result of such a merge would look like:</p>
 	<b class="package"><a href="critcl_enum.html">critcl::enum</a></b></p></li>
 </ol>
 </div>
-<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.11</a></h2>
+<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.11</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #37, via pull request #38, with thanks to
        Jos DeCoster. Information was stored into the v::delproc
@@ -761,7 +777,7 @@ targets. The result of such a merge would look like:</p>
        Built on top of <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p></li>
 </ol>
 </div>
-<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.10</a></h2>
+<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.10</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed code version numbering forgotten with 3.1.9.</p></li>
 <li><p>Fixed issue #35. In package mode (-pkg) the object cache
@@ -777,7 +793,7 @@ targets. The result of such a merge would look like:</p>
 	sources. Bug and fix reported by Peter Spjuth.</p></li>
 </ol>
 </div>
-<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.9</a></h2>
+<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.9</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #27. Added missing platform definitions for
 	various alternate linux and OS X targets.</p></li>
@@ -801,7 +817,7 @@ targets. The result of such a merge would look like:</p>
 <li><p>Fixed issue #34. Handle files starting with a dot better.</p></li>
 </ol>
 </div>
-<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.8</a></h2>
+<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.8</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue with package indices generated for Tcl 8.4.
 	Join the list of commands with semi-colon, not newline.</p></li>
@@ -809,7 +825,7 @@ targets. The result of such a merge would look like:</p>
 	consider while fixing bug #21 (see critcl 3.1.6).</p></li>
 </ol>
 </div>
-<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.7</a></h2>
+<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #24. Extract and unconditionally display compiler
 	warnings found in the build log. Prevents users from missing
@@ -822,7 +838,7 @@ targets. The result of such a merge would look like:</p>
 	inherit values from configurations defined before them.</p></li>
 </ol>
 </div>
-<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.6</a></h2>
+<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #21. While the multi-definition of the stub-table
        pointer variables was ok with for all the C linkers seen so far
@@ -844,7 +860,7 @@ targets. The result of such a merge would look like:</p>
 <li><p>Fixed issue #23.</p></li>
 </ol>
 </div>
-<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.5</a></h2>
+<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #19. Made the regular expression extracting the
        MSVC version number more general to make it work on german
@@ -854,7 +870,7 @@ targets. The result of such a merge would look like:</p>
        a unix emulation environment like msys/mingw.</p></li>
 </ol>
 </div>
-<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.4</a></h2>
+<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfix in package <b class="package"><a href="critcl_class.html">critcl::class</a></b>. Generate a dummy
        field in the class structure if the class has no class
@@ -865,7 +881,7 @@ targets. The result of such a merge would look like:</p>
        <b class="cmd"><a href="critcl_class.html">critcl::class</a></b>.</p></li>
 </ol>
 </div>
-<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.3</a></h2>
+<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Added new argument type &quot;pstring&quot;, for &quot;Pascal String&quot;, a
@@ -881,7 +897,7 @@ targets. The result of such a merge would look like:</p>
        Versions bumped to 1.0.4 and 1.0.1 respectively.</p></li>
 </ol>
 </div>
-<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.2</a></h2>
+<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Extended <b class="cmd">critcl::cproc</b> to be able to handle optional
@@ -892,7 +908,7 @@ targets. The result of such a merge would look like:</p>
        emulation package <b class="package">lassign84</b> to 1.0.1.</p></li>
 </ol>
 </div>
-<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.1</a></h2>
+<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed the generation of wrong#args errors for
@@ -906,7 +922,7 @@ separators. Bumped to version 1.0.1.</p></li>
 instance creation for clarity. Bumped to version 1.0.2.</p></li>
 </ol>
 </div>
-<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1</a></h2>
+<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Added a new higher-level package <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p>
 <p>This package simplifies the creation of code associating data
@@ -965,7 +981,7 @@ define custom argument and result types for <b class="cmd">::critcl::cproc</b>.<
 details of the provided commands.</p></li>
 </ol>
 </div>
-<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.0.7</a></h2>
+<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.0.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed the code generated by <b class="cmd">critcl::c++command</b>.
         The emitted code handed a non-static string table to
@@ -975,7 +991,7 @@ details of the provided commands.</p></li>
 	us to the general problem.</p></li>
 </ol>
 </div>
-<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.0.6</a></h2>
+<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.0.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issue 10. The critcl application now delivers a
 	proper exit code (1) on build failure, instead of always
@@ -988,7 +1004,7 @@ details of the provided commands.</p></li>
 	the README.md shown by github</p></li>
 </ol>
 </div>
-<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.0.5</a></h2>
+<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug in the new code for #line pragmas triggered when
 	specifying C code without leading whitespace.</p></li>
@@ -996,7 +1012,7 @@ details of the provided commands.</p></li>
 	source retrieval, installer, and developer's guides.</p></li>
 </ol>
 </div>
-<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.4</a></h2>
+<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed generation of the package's initname when the incoming
 	code is read from stdin and has no proper path.</p></li>
@@ -1026,7 +1042,7 @@ details of the provided commands.</p></li>
 	release.</p></li>
 </ol>
 </div>
-<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.3</a></h2>
+<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.0.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issues 5 and 8, for the example build.tcl
 scripts. Working around a missing variable ::errorInfo. It should
@@ -1034,7 +1050,7 @@ always be present, however there seem to be revisions of Tcl around
 which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.0.2</a></h2>
+<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.0.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue in compile-and-run mode where commands put into the
 auto_index are not found by Tcl's [unknown] command.</p></li>
@@ -1047,7 +1063,7 @@ option <b class="option">-I</b>, just for library search paths.</p></li>
 revisions of Tcl around which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.0.1</a></h2>
+<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3.0.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed recording of Tcl version requirements. Keep package name
@@ -1078,7 +1094,7 @@ for the library in the paths specified by the environment variable
 LIB.</p></li>
 </ol>
 </div>
-<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3</a></h2>
+<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>The command <b class="cmd">critcl::platform</b> was deprecated in version
 2.1, superceded by <b class="cmd">critcl::targetplatform</b>, yet kept for
@@ -1145,7 +1161,7 @@ for/about the package.</p>
 <b class="package"><a href="critcl_pkg.html">critcl</a></b> package documentation for details.</p></li>
 </ol>
 </div>
-<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 2.1</a></h2>
+<div id="section33" class="doctools_section"><h2><a name="section33">Changes for version 2.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug where <b class="cmd">critcl::tsources</b> interpreted relative
 paths as relative to the current working directory instead of
@@ -1242,10 +1258,10 @@ still using proper path names and init function.</p></li>
 <li><p>Dropped remnants of support for Tcl 8.3 and before.</p></li>
 </ol>
 </div>
-<div id="section33" class="doctools_section"><h2><a name="section33">Authors</a></h2>
+<div id="section34" class="doctools_section"><h2><a name="section34">Authors</a></h2>
 <p>Jean Claude Wippler, Steve Landers, Andreas Kupries</p>
 </div>
-<div id="section34" class="doctools_section"><h2><a name="section34">Bugs, Ideas, Feedback</a></h2>
+<div id="section35" class="doctools_section"><h2><a name="section35">Bugs, Ideas, Feedback</a></h2>
 <p>This document, and the package it describes, will undoubtedly contain
 bugs and other problems.
 Please report them at <a href="https://github.com/andreas-kupries/critcl/issues">https://github.com/andreas-kupries/critcl/issues</a>.

--- a/embedded/www/files/critcl_app.html
+++ b/embedded/www/files/critcl_app.html
@@ -450,11 +450,11 @@ targets. The result of such a merge would look like:</p>
 <p>Moved the command activating more precise code location
        tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
        <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
-<p>The ahead of time compilation of the <i class="term">package</i> mode done
-       by the application (package) can bear the performance penalty
-       invoked by this <em>global</em> setting.</p>
-<p>Arbitrary libraries and applications using critcl dynamically,
-       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+<p>Because generating packages ahead of time can bear the
+       performance penalty invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically
+       (<i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>) on the other hand likely cannot, and
+       should not.</p></li>
 </ol>
 </div>
 <div id="section5" class="doctools_section"><h2><a name="section5">Changes for version 3.1.18.1</a></h2>

--- a/embedded/www/files/critcl_apppkg.html
+++ b/embedded/www/files/critcl_apppkg.html
@@ -497,11 +497,11 @@ targets. The result of such a merge would look like:</p>
 <p>Moved the command activating more precise code location
        tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
        <b class="package">critcl::app</b>.</p>
-<p>The ahead of time compilation of the <i class="term">package</i> mode done
-       by the application (package) can bear the performance penalty
-       invoked by this <em>global</em> setting.</p>
-<p>Arbitrary libraries and applications using critcl dynamically,
-       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+<p>Because generating packages ahead of time can bear the
+       performance penalty invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically
+       (<i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>) on the other hand likely cannot, and
+       should not.</p></li>
 </ol>
 </div>
 <div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.18.1</a></h2>

--- a/embedded/www/files/critcl_apppkg.html
+++ b/embedded/www/files/critcl_apppkg.html
@@ -102,7 +102,7 @@
 &#124; <a href="../index.html">Keyword Index</a>
  ] <hr>
 <div class="doctools">
-<h1 class="doctools_title">critcl::app(n) 3.1.18 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
+<h1 class="doctools_title">critcl::app(n) 3.1.18.2 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
 <div id="name" class="doctools_section"><h2><a name="name">Name</a></h2>
 <p>critcl::app - CriTcl - Application Package Reference</p>
 </div>
@@ -115,37 +115,38 @@
 <li class="doctools_section"><a href="#section3">Options</a></li>
 <li class="doctools_section"><a href="#section4">Modes Of Operation/Use</a></li>
 <li class="doctools_section"><a href="#section5">Package Structure</a></li>
-<li class="doctools_section"><a href="#section6">Changes for version 3.1.18.1</a></li>
-<li class="doctools_section"><a href="#section7">Changes for version 3.1.18</a></li>
-<li class="doctools_section"><a href="#section8">Changes for version 3.1.17</a></li>
-<li class="doctools_section"><a href="#section9">Changes for version 3.1.16</a></li>
-<li class="doctools_section"><a href="#section10">Changes for version 3.1.15</a></li>
-<li class="doctools_section"><a href="#section11">Changes for version 3.1.14</a></li>
-<li class="doctools_section"><a href="#section12">Changes for version 3.1.13</a></li>
-<li class="doctools_section"><a href="#section13">Changes for version 3.1.12</a></li>
-<li class="doctools_section"><a href="#section14">Changes for version 3.1.11</a></li>
-<li class="doctools_section"><a href="#section15">Changes for version 3.1.10</a></li>
-<li class="doctools_section"><a href="#section16">Changes for version 3.1.9</a></li>
-<li class="doctools_section"><a href="#section17">Changes for version 3.1.8</a></li>
-<li class="doctools_section"><a href="#section18">Changes for version 3.1.7</a></li>
-<li class="doctools_section"><a href="#section19">Changes for version 3.1.6</a></li>
-<li class="doctools_section"><a href="#section20">Changes for version 3.1.5</a></li>
-<li class="doctools_section"><a href="#section21">Changes for version 3.1.4</a></li>
-<li class="doctools_section"><a href="#section22">Changes for version 3.1.3</a></li>
-<li class="doctools_section"><a href="#section23">Changes for version 3.1.2</a></li>
-<li class="doctools_section"><a href="#section24">Changes for version 3.1.1</a></li>
-<li class="doctools_section"><a href="#section25">Changes for version 3.1</a></li>
-<li class="doctools_section"><a href="#section26">Changes for version 3.0.7</a></li>
-<li class="doctools_section"><a href="#section27">Changes for version 3.0.6</a></li>
-<li class="doctools_section"><a href="#section28">Changes for version 3.0.5</a></li>
-<li class="doctools_section"><a href="#section29">Changes for version 3.0.4</a></li>
-<li class="doctools_section"><a href="#section30">Changes for version 3.0.3</a></li>
-<li class="doctools_section"><a href="#section31">Changes for version 3.0.2</a></li>
-<li class="doctools_section"><a href="#section32">Changes for version 3.0.1</a></li>
-<li class="doctools_section"><a href="#section33">Changes for version 3</a></li>
-<li class="doctools_section"><a href="#section34">Changes for version 2.1</a></li>
-<li class="doctools_section"><a href="#section35">Authors</a></li>
-<li class="doctools_section"><a href="#section36">Bugs, Ideas, Feedback</a></li>
+<li class="doctools_section"><a href="#section6">Changes for version 3.1.18.2</a></li>
+<li class="doctools_section"><a href="#section7">Changes for version 3.1.18.1</a></li>
+<li class="doctools_section"><a href="#section8">Changes for version 3.1.18</a></li>
+<li class="doctools_section"><a href="#section9">Changes for version 3.1.17</a></li>
+<li class="doctools_section"><a href="#section10">Changes for version 3.1.16</a></li>
+<li class="doctools_section"><a href="#section11">Changes for version 3.1.15</a></li>
+<li class="doctools_section"><a href="#section12">Changes for version 3.1.14</a></li>
+<li class="doctools_section"><a href="#section13">Changes for version 3.1.13</a></li>
+<li class="doctools_section"><a href="#section14">Changes for version 3.1.12</a></li>
+<li class="doctools_section"><a href="#section15">Changes for version 3.1.11</a></li>
+<li class="doctools_section"><a href="#section16">Changes for version 3.1.10</a></li>
+<li class="doctools_section"><a href="#section17">Changes for version 3.1.9</a></li>
+<li class="doctools_section"><a href="#section18">Changes for version 3.1.8</a></li>
+<li class="doctools_section"><a href="#section19">Changes for version 3.1.7</a></li>
+<li class="doctools_section"><a href="#section20">Changes for version 3.1.6</a></li>
+<li class="doctools_section"><a href="#section21">Changes for version 3.1.5</a></li>
+<li class="doctools_section"><a href="#section22">Changes for version 3.1.4</a></li>
+<li class="doctools_section"><a href="#section23">Changes for version 3.1.3</a></li>
+<li class="doctools_section"><a href="#section24">Changes for version 3.1.2</a></li>
+<li class="doctools_section"><a href="#section25">Changes for version 3.1.1</a></li>
+<li class="doctools_section"><a href="#section26">Changes for version 3.1</a></li>
+<li class="doctools_section"><a href="#section27">Changes for version 3.0.7</a></li>
+<li class="doctools_section"><a href="#section28">Changes for version 3.0.6</a></li>
+<li class="doctools_section"><a href="#section29">Changes for version 3.0.5</a></li>
+<li class="doctools_section"><a href="#section30">Changes for version 3.0.4</a></li>
+<li class="doctools_section"><a href="#section31">Changes for version 3.0.3</a></li>
+<li class="doctools_section"><a href="#section32">Changes for version 3.0.2</a></li>
+<li class="doctools_section"><a href="#section33">Changes for version 3.0.1</a></li>
+<li class="doctools_section"><a href="#section34">Changes for version 3</a></li>
+<li class="doctools_section"><a href="#section35">Changes for version 2.1</a></li>
+<li class="doctools_section"><a href="#section36">Authors</a></li>
+<li class="doctools_section"><a href="#section37">Bugs, Ideas, Feedback</a></li>
 <li class="doctools_section"><a href="#keywords">Keywords</a></li>
 <li class="doctools_section"><a href="#category">Category</a></li>
 <li class="doctools_section"><a href="#copyright">Copyright</a></li>
@@ -155,7 +156,7 @@
 <div class="doctools_synopsis">
 <ul class="doctools_requirements">
 <li>package require <b class="pkgname">Tcl 8.4</b></li>
-<li>package require <b class="pkgname">critcl::app <span class="opt">?3.1.18?</span></b></li>
+<li>package require <b class="pkgname">critcl::app <span class="opt">?3.1.18.2?</span></b></li>
 <li>package require <b class="pkgname">critcl <span class="opt">?2?</span></b></li>
 <li>package require <b class="pkgname">platform <span class="opt">?1.0.2?</span></b></li>
 <li>package require <b class="pkgname">cmdline</b></li>
@@ -488,7 +489,22 @@ targets. The result of such a merge would look like:</p>
 </pre>
 <p>The latest changes are found at the top.</p>
 </div>
-<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.18.1</a></h2>
+<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.18.2</a></h2>
+<p><em>Not Released Yet</em></p>
+<ol class="doctools_enumerated">
+<li><p><em>Performance Fix</em> for <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> mode.
+       Issue #112.</p>
+<p>Moved the command activating more precise code location
+       tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
+       <b class="package">critcl::app</b>.</p>
+<p>The ahead of time compilation of the <i class="term">package</i> mode done
+       by the application (package) can bear the performance penalty
+       invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically,
+       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+</ol>
+</div>
+<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.18.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p><em>Attention</em>: While the overall version (of the bundle)
        moves to 3.1.18.1 the versions of packages <b class="package"><a href="critcl_pkg.html">critcl</a></b> and
@@ -501,7 +517,7 @@ targets. The result of such a merge would look like:</p>
        compilation of the generated code.</p></li>
 </ol>
 </div>
-<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.18</a></h2>
+<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.18</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Feature (Developer support). Merged pull request #96 from
        sebres/main-direct-invoke. Enables direct invokation of the
@@ -579,7 +595,7 @@ targets. The result of such a merge would look like:</p>
 <p>See the package reference for the details.</p></li>
 </ol>
 </div>
-<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.17</a></h2>
+<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.17</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Extension: Allow duplicate arg- and result-type definitions if
        they are fully identical.</p></li>
@@ -631,7 +647,7 @@ targets. The result of such a merge would look like:</p>
        default. Both modes can be used together.</p></li>
 </ol>
 </div>
-<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.16</a></h2>
+<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.16</a></h2>
 <ol class="doctools_enumerated">
 <li><p>New feature. Extended <b class="cmd">critcl::cproc</b>'s argument handling
        to allow arbitrary mixing of required and optional arguments.</p></li>
@@ -677,12 +693,12 @@ targets. The result of such a merge would look like:</p>
        is limited to mode <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>.</p></li>
 </ol>
 </div>
-<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.15</a></h2>
+<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.15</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed version number bogosity with <b class="const">3.1.14</b>.</p></li>
 </ol>
 </div>
-<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.14</a></h2>
+<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.14</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #36. Added message to target <b class="const">all</b> of the
         Makefile generated for TEA mode. Additionally tweaked other
@@ -712,7 +728,7 @@ targets. The result of such a merge would look like:</p>
         location of the troubling declaration.</p></li>
 </ol>
 </div>
-<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.13</a></h2>
+<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.13</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Merged PR #43. Fixed bug loading adjunct Tcl sources.</p></li>
 <li><p>Fixes in documentation and generated code of package
@@ -763,7 +779,7 @@ targets. The result of such a merge would look like:</p>
 	a fix as they are all built on top of &quot;iassoc&quot;.</p></li>
 </ol>
 </div>
-<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.12</a></h2>
+<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.12</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue 42. Clear ::errorInfo immediately after startup to
        prevent leakage of irrelevant (caught) errors into our script
@@ -788,7 +804,7 @@ targets. The result of such a merge would look like:</p>
 	<b class="package"><a href="critcl_enum.html">critcl::enum</a></b></p></li>
 </ol>
 </div>
-<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.11</a></h2>
+<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.11</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #37, via pull request #38, with thanks to
        Jos DeCoster. Information was stored into the v::delproc
@@ -808,7 +824,7 @@ targets. The result of such a merge would look like:</p>
        Built on top of <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p></li>
 </ol>
 </div>
-<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.10</a></h2>
+<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.10</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed code version numbering forgotten with 3.1.9.</p></li>
 <li><p>Fixed issue #35. In package mode (-pkg) the object cache
@@ -824,7 +840,7 @@ targets. The result of such a merge would look like:</p>
 	sources. Bug and fix reported by Peter Spjuth.</p></li>
 </ol>
 </div>
-<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.9</a></h2>
+<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.9</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #27. Added missing platform definitions for
 	various alternate linux and OS X targets.</p></li>
@@ -848,7 +864,7 @@ targets. The result of such a merge would look like:</p>
 <li><p>Fixed issue #34. Handle files starting with a dot better.</p></li>
 </ol>
 </div>
-<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.8</a></h2>
+<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.8</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue with package indices generated for Tcl 8.4.
 	Join the list of commands with semi-colon, not newline.</p></li>
@@ -856,7 +872,7 @@ targets. The result of such a merge would look like:</p>
 	consider while fixing bug #21 (see critcl 3.1.6).</p></li>
 </ol>
 </div>
-<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.7</a></h2>
+<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #24. Extract and unconditionally display compiler
 	warnings found in the build log. Prevents users from missing
@@ -869,7 +885,7 @@ targets. The result of such a merge would look like:</p>
 	inherit values from configurations defined before them.</p></li>
 </ol>
 </div>
-<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.6</a></h2>
+<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #21. While the multi-definition of the stub-table
        pointer variables was ok with for all the C linkers seen so far
@@ -891,7 +907,7 @@ targets. The result of such a merge would look like:</p>
 <li><p>Fixed issue #23.</p></li>
 </ol>
 </div>
-<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.5</a></h2>
+<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #19. Made the regular expression extracting the
        MSVC version number more general to make it work on german
@@ -901,7 +917,7 @@ targets. The result of such a merge would look like:</p>
        a unix emulation environment like msys/mingw.</p></li>
 </ol>
 </div>
-<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.4</a></h2>
+<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfix in package <b class="package"><a href="critcl_class.html">critcl::class</a></b>. Generate a dummy
        field in the class structure if the class has no class
@@ -912,7 +928,7 @@ targets. The result of such a merge would look like:</p>
        <b class="cmd"><a href="critcl_class.html">critcl::class</a></b>.</p></li>
 </ol>
 </div>
-<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.3</a></h2>
+<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Added new argument type &quot;pstring&quot;, for &quot;Pascal String&quot;, a
@@ -928,7 +944,7 @@ targets. The result of such a merge would look like:</p>
        Versions bumped to 1.0.4 and 1.0.1 respectively.</p></li>
 </ol>
 </div>
-<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1.2</a></h2>
+<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.1.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Extended <b class="cmd">critcl::cproc</b> to be able to handle optional
@@ -939,7 +955,7 @@ targets. The result of such a merge would look like:</p>
        emulation package <b class="package">lassign84</b> to 1.0.1.</p></li>
 </ol>
 </div>
-<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.1.1</a></h2>
+<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.1.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed the generation of wrong#args errors for
@@ -953,7 +969,7 @@ separators. Bumped to version 1.0.1.</p></li>
 instance creation for clarity. Bumped to version 1.0.2.</p></li>
 </ol>
 </div>
-<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.1</a></h2>
+<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Added a new higher-level package <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p>
 <p>This package simplifies the creation of code associating data
@@ -1012,7 +1028,7 @@ define custom argument and result types for <b class="cmd">::critcl::cproc</b>.<
 details of the provided commands.</p></li>
 </ol>
 </div>
-<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.0.7</a></h2>
+<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed the code generated by <b class="cmd">critcl::c++command</b>.
         The emitted code handed a non-static string table to
@@ -1022,7 +1038,7 @@ details of the provided commands.</p></li>
 	us to the general problem.</p></li>
 </ol>
 </div>
-<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.6</a></h2>
+<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issue 10. The critcl application now delivers a
 	proper exit code (1) on build failure, instead of always
@@ -1035,7 +1051,7 @@ details of the provided commands.</p></li>
 	the README.md shown by github</p></li>
 </ol>
 </div>
-<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.5</a></h2>
+<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.0.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug in the new code for #line pragmas triggered when
 	specifying C code without leading whitespace.</p></li>
@@ -1043,7 +1059,7 @@ details of the provided commands.</p></li>
 	source retrieval, installer, and developer's guides.</p></li>
 </ol>
 </div>
-<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.0.4</a></h2>
+<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.0.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed generation of the package's initname when the incoming
 	code is read from stdin and has no proper path.</p></li>
@@ -1073,7 +1089,7 @@ details of the provided commands.</p></li>
 	release.</p></li>
 </ol>
 </div>
-<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.0.3</a></h2>
+<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3.0.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issues 5 and 8, for the example build.tcl
 scripts. Working around a missing variable ::errorInfo. It should
@@ -1081,7 +1097,7 @@ always be present, however there seem to be revisions of Tcl around
 which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3.0.2</a></h2>
+<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 3.0.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue in compile-and-run mode where commands put into the
 auto_index are not found by Tcl's [unknown] command.</p></li>
@@ -1094,7 +1110,7 @@ option <b class="option">-I</b>, just for library search paths.</p></li>
 revisions of Tcl around which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 3.0.1</a></h2>
+<div id="section33" class="doctools_section"><h2><a name="section33">Changes for version 3.0.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed recording of Tcl version requirements. Keep package name
@@ -1125,7 +1141,7 @@ for the library in the paths specified by the environment variable
 LIB.</p></li>
 </ol>
 </div>
-<div id="section33" class="doctools_section"><h2><a name="section33">Changes for version 3</a></h2>
+<div id="section34" class="doctools_section"><h2><a name="section34">Changes for version 3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>The command <b class="cmd">critcl::platform</b> was deprecated in version
 2.1, superceded by <b class="cmd">critcl::targetplatform</b>, yet kept for
@@ -1192,7 +1208,7 @@ for/about the package.</p>
 <b class="package"><a href="critcl_pkg.html">critcl</a></b> package documentation for details.</p></li>
 </ol>
 </div>
-<div id="section34" class="doctools_section"><h2><a name="section34">Changes for version 2.1</a></h2>
+<div id="section35" class="doctools_section"><h2><a name="section35">Changes for version 2.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug where <b class="cmd">critcl::tsources</b> interpreted relative
 paths as relative to the current working directory instead of
@@ -1289,10 +1305,10 @@ still using proper path names and init function.</p></li>
 <li><p>Dropped remnants of support for Tcl 8.3 and before.</p></li>
 </ol>
 </div>
-<div id="section35" class="doctools_section"><h2><a name="section35">Authors</a></h2>
+<div id="section36" class="doctools_section"><h2><a name="section36">Authors</a></h2>
 <p>Jean Claude Wippler, Steve Landers, Andreas Kupries</p>
 </div>
-<div id="section36" class="doctools_section"><h2><a name="section36">Bugs, Ideas, Feedback</a></h2>
+<div id="section37" class="doctools_section"><h2><a name="section37">Bugs, Ideas, Feedback</a></h2>
 <p>This document, and the package it describes, will undoubtedly contain
 bugs and other problems.
 Please report them at <a href="https://github.com/andreas-kupries/critcl/issues">https://github.com/andreas-kupries/critcl/issues</a>.

--- a/embedded/www/files/critcl_cproc.html
+++ b/embedded/www/files/critcl_cproc.html
@@ -102,7 +102,7 @@
 &#124; <a href="../index.html">Keyword Index</a>
  ] <hr>
 <div class="doctools">
-<h1 class="doctools_title">critcl-cproc-types(n) 3.1.18 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
+<h1 class="doctools_title">critcl-cproc-types(n) 3.1.18.2 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
 <div id="name" class="doctools_section"><h2><a name="name">Name</a></h2>
 <p>critcl-cproc-types - CriTcl - cproc Type Reference</p>
 </div>
@@ -135,7 +135,7 @@
 <div class="doctools_synopsis">
 <ul class="doctools_requirements">
 <li>package require <b class="pkgname">Tcl 8.4</b></li>
-<li>package require <b class="pkgname">critcl <span class="opt">?3.1.18?</span></b></li>
+<li>package require <b class="pkgname">critcl <span class="opt">?3.1.18.2?</span></b></li>
 </ul>
 <ul class="doctools_syntax">
 <li><a href="#1"><b class="cmd">::critcl::has-resulttype</b> <i class="arg">name</i></a></li>

--- a/embedded/www/files/critcl_introduction.html
+++ b/embedded/www/files/critcl_introduction.html
@@ -322,11 +322,11 @@ paragraph.</p>
 <p>Moved the command activating more precise code location
        tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
        <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
-<p>The ahead of time compilation of the <i class="term">package</i> mode done
-       by the application (package) can bear the performance penalty
-       invoked by this <em>global</em> setting.</p>
-<p>Arbitrary libraries and applications using critcl dynamically,
-       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+<p>Because generating packages ahead of time can bear the
+       performance penalty invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically
+       (<i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>) on the other hand likely cannot, and
+       should not.</p></li>
 </ol>
 </div>
 <div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.18.1</a></h2>

--- a/embedded/www/files/critcl_introduction.html
+++ b/embedded/www/files/critcl_introduction.html
@@ -118,37 +118,38 @@
 <li class="doctools_section"><a href="#section7">Modes Of Operation/Use</a></li>
 <li class="doctools_section"><a href="#section8">System Architecture</a></li>
 <li class="doctools_section"><a href="#section9">Examples</a></li>
-<li class="doctools_section"><a href="#section10">Changes for version 3.1.18.1</a></li>
-<li class="doctools_section"><a href="#section11">Changes for version 3.1.18</a></li>
-<li class="doctools_section"><a href="#section12">Changes for version 3.1.17</a></li>
-<li class="doctools_section"><a href="#section13">Changes for version 3.1.16</a></li>
-<li class="doctools_section"><a href="#section14">Changes for version 3.1.15</a></li>
-<li class="doctools_section"><a href="#section15">Changes for version 3.1.14</a></li>
-<li class="doctools_section"><a href="#section16">Changes for version 3.1.13</a></li>
-<li class="doctools_section"><a href="#section17">Changes for version 3.1.12</a></li>
-<li class="doctools_section"><a href="#section18">Changes for version 3.1.11</a></li>
-<li class="doctools_section"><a href="#section19">Changes for version 3.1.10</a></li>
-<li class="doctools_section"><a href="#section20">Changes for version 3.1.9</a></li>
-<li class="doctools_section"><a href="#section21">Changes for version 3.1.8</a></li>
-<li class="doctools_section"><a href="#section22">Changes for version 3.1.7</a></li>
-<li class="doctools_section"><a href="#section23">Changes for version 3.1.6</a></li>
-<li class="doctools_section"><a href="#section24">Changes for version 3.1.5</a></li>
-<li class="doctools_section"><a href="#section25">Changes for version 3.1.4</a></li>
-<li class="doctools_section"><a href="#section26">Changes for version 3.1.3</a></li>
-<li class="doctools_section"><a href="#section27">Changes for version 3.1.2</a></li>
-<li class="doctools_section"><a href="#section28">Changes for version 3.1.1</a></li>
-<li class="doctools_section"><a href="#section29">Changes for version 3.1</a></li>
-<li class="doctools_section"><a href="#section30">Changes for version 3.0.7</a></li>
-<li class="doctools_section"><a href="#section31">Changes for version 3.0.6</a></li>
-<li class="doctools_section"><a href="#section32">Changes for version 3.0.5</a></li>
-<li class="doctools_section"><a href="#section33">Changes for version 3.0.4</a></li>
-<li class="doctools_section"><a href="#section34">Changes for version 3.0.3</a></li>
-<li class="doctools_section"><a href="#section35">Changes for version 3.0.2</a></li>
-<li class="doctools_section"><a href="#section36">Changes for version 3.0.1</a></li>
-<li class="doctools_section"><a href="#section37">Changes for version 3</a></li>
-<li class="doctools_section"><a href="#section38">Changes for version 2.1</a></li>
-<li class="doctools_section"><a href="#section39">Authors</a></li>
-<li class="doctools_section"><a href="#section40">Bugs, Ideas, Feedback</a></li>
+<li class="doctools_section"><a href="#section10">Changes for version 3.1.18.2</a></li>
+<li class="doctools_section"><a href="#section11">Changes for version 3.1.18.1</a></li>
+<li class="doctools_section"><a href="#section12">Changes for version 3.1.18</a></li>
+<li class="doctools_section"><a href="#section13">Changes for version 3.1.17</a></li>
+<li class="doctools_section"><a href="#section14">Changes for version 3.1.16</a></li>
+<li class="doctools_section"><a href="#section15">Changes for version 3.1.15</a></li>
+<li class="doctools_section"><a href="#section16">Changes for version 3.1.14</a></li>
+<li class="doctools_section"><a href="#section17">Changes for version 3.1.13</a></li>
+<li class="doctools_section"><a href="#section18">Changes for version 3.1.12</a></li>
+<li class="doctools_section"><a href="#section19">Changes for version 3.1.11</a></li>
+<li class="doctools_section"><a href="#section20">Changes for version 3.1.10</a></li>
+<li class="doctools_section"><a href="#section21">Changes for version 3.1.9</a></li>
+<li class="doctools_section"><a href="#section22">Changes for version 3.1.8</a></li>
+<li class="doctools_section"><a href="#section23">Changes for version 3.1.7</a></li>
+<li class="doctools_section"><a href="#section24">Changes for version 3.1.6</a></li>
+<li class="doctools_section"><a href="#section25">Changes for version 3.1.5</a></li>
+<li class="doctools_section"><a href="#section26">Changes for version 3.1.4</a></li>
+<li class="doctools_section"><a href="#section27">Changes for version 3.1.3</a></li>
+<li class="doctools_section"><a href="#section28">Changes for version 3.1.2</a></li>
+<li class="doctools_section"><a href="#section29">Changes for version 3.1.1</a></li>
+<li class="doctools_section"><a href="#section30">Changes for version 3.1</a></li>
+<li class="doctools_section"><a href="#section31">Changes for version 3.0.7</a></li>
+<li class="doctools_section"><a href="#section32">Changes for version 3.0.6</a></li>
+<li class="doctools_section"><a href="#section33">Changes for version 3.0.5</a></li>
+<li class="doctools_section"><a href="#section34">Changes for version 3.0.4</a></li>
+<li class="doctools_section"><a href="#section35">Changes for version 3.0.3</a></li>
+<li class="doctools_section"><a href="#section36">Changes for version 3.0.2</a></li>
+<li class="doctools_section"><a href="#section37">Changes for version 3.0.1</a></li>
+<li class="doctools_section"><a href="#section38">Changes for version 3</a></li>
+<li class="doctools_section"><a href="#section39">Changes for version 2.1</a></li>
+<li class="doctools_section"><a href="#section40">Authors</a></li>
+<li class="doctools_section"><a href="#section41">Bugs, Ideas, Feedback</a></li>
 <li class="doctools_section"><a href="#keywords">Keywords</a></li>
 <li class="doctools_section"><a href="#category">Category</a></li>
 <li class="doctools_section"><a href="#copyright">Copyright</a></li>
@@ -313,7 +314,22 @@ overall picture shown by the large examples mentioned in the previous
 paragraph.</p>
 <p>The latest changes are found at the top.</p>
 </div>
-<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.18.1</a></h2>
+<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.18.2</a></h2>
+<p><em>Not Released Yet</em></p>
+<ol class="doctools_enumerated">
+<li><p><em>Performance Fix</em> for <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> mode.
+       Issue #112.</p>
+<p>Moved the command activating more precise code location
+       tracking out of package <b class="package"><a href="critcl_pkg.html">critcl</a></b> into package
+       <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
+<p>The ahead of time compilation of the <i class="term">package</i> mode done
+       by the application (package) can bear the performance penalty
+       invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically,
+       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+</ol>
+</div>
+<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.18.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p><em>Attention</em>: While the overall version (of the bundle)
        moves to 3.1.18.1 the versions of packages <b class="package"><a href="critcl_pkg.html">critcl</a></b> and
@@ -326,7 +342,7 @@ paragraph.</p>
        compilation of the generated code.</p></li>
 </ol>
 </div>
-<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.18</a></h2>
+<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.18</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Feature (Developer support). Merged pull request #96 from
        sebres/main-direct-invoke. Enables direct invokation of the
@@ -404,7 +420,7 @@ paragraph.</p>
 <p>See the package reference for the details.</p></li>
 </ol>
 </div>
-<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.17</a></h2>
+<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.17</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Extension: Allow duplicate arg- and result-type definitions if
        they are fully identical.</p></li>
@@ -456,7 +472,7 @@ paragraph.</p>
        default. Both modes can be used together.</p></li>
 </ol>
 </div>
-<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.16</a></h2>
+<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.16</a></h2>
 <ol class="doctools_enumerated">
 <li><p>New feature. Extended <b class="cmd">critcl::cproc</b>'s argument handling
        to allow arbitrary mixing of required and optional arguments.</p></li>
@@ -502,12 +518,12 @@ paragraph.</p>
        is limited to mode <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>.</p></li>
 </ol>
 </div>
-<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.15</a></h2>
+<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.15</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed version number bogosity with <b class="const">3.1.14</b>.</p></li>
 </ol>
 </div>
-<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.14</a></h2>
+<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.14</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #36. Added message to target <b class="const">all</b> of the
         Makefile generated for TEA mode. Additionally tweaked other
@@ -537,7 +553,7 @@ paragraph.</p>
         location of the troubling declaration.</p></li>
 </ol>
 </div>
-<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.13</a></h2>
+<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.13</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Merged PR #43. Fixed bug loading adjunct Tcl sources.</p></li>
 <li><p>Fixes in documentation and generated code of package
@@ -588,7 +604,7 @@ paragraph.</p>
 	a fix as they are all built on top of &quot;iassoc&quot;.</p></li>
 </ol>
 </div>
-<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.12</a></h2>
+<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.12</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue 42. Clear ::errorInfo immediately after startup to
        prevent leakage of irrelevant (caught) errors into our script
@@ -613,7 +629,7 @@ paragraph.</p>
 	<b class="package"><a href="critcl_enum.html">critcl::enum</a></b></p></li>
 </ol>
 </div>
-<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.11</a></h2>
+<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.11</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #37, via pull request #38, with thanks to
        Jos DeCoster. Information was stored into the v::delproc
@@ -633,7 +649,7 @@ paragraph.</p>
        Built on top of <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p></li>
 </ol>
 </div>
-<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.10</a></h2>
+<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.10</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed code version numbering forgotten with 3.1.9.</p></li>
 <li><p>Fixed issue #35. In package mode (-pkg) the object cache
@@ -649,7 +665,7 @@ paragraph.</p>
 	sources. Bug and fix reported by Peter Spjuth.</p></li>
 </ol>
 </div>
-<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.9</a></h2>
+<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.9</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #27. Added missing platform definitions for
 	various alternate linux and OS X targets.</p></li>
@@ -673,7 +689,7 @@ paragraph.</p>
 <li><p>Fixed issue #34. Handle files starting with a dot better.</p></li>
 </ol>
 </div>
-<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.8</a></h2>
+<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.8</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue with package indices generated for Tcl 8.4.
 	Join the list of commands with semi-colon, not newline.</p></li>
@@ -681,7 +697,7 @@ paragraph.</p>
 	consider while fixing bug #21 (see critcl 3.1.6).</p></li>
 </ol>
 </div>
-<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.7</a></h2>
+<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #24. Extract and unconditionally display compiler
 	warnings found in the build log. Prevents users from missing
@@ -694,7 +710,7 @@ paragraph.</p>
 	inherit values from configurations defined before them.</p></li>
 </ol>
 </div>
-<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1.6</a></h2>
+<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.1.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #21. While the multi-definition of the stub-table
        pointer variables was ok with for all the C linkers seen so far
@@ -716,7 +732,7 @@ paragraph.</p>
 <li><p>Fixed issue #23.</p></li>
 </ol>
 </div>
-<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.1.5</a></h2>
+<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.1.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #19. Made the regular expression extracting the
        MSVC version number more general to make it work on german
@@ -726,7 +742,7 @@ paragraph.</p>
        a unix emulation environment like msys/mingw.</p></li>
 </ol>
 </div>
-<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.1.4</a></h2>
+<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.1.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfix in package <b class="package"><a href="critcl_class.html">critcl::class</a></b>. Generate a dummy
        field in the class structure if the class has no class
@@ -737,7 +753,7 @@ paragraph.</p>
        <b class="cmd"><a href="critcl_class.html">critcl::class</a></b>.</p></li>
 </ol>
 </div>
-<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.1.3</a></h2>
+<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.1.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Added new argument type &quot;pstring&quot;, for &quot;Pascal String&quot;, a
@@ -753,7 +769,7 @@ paragraph.</p>
        Versions bumped to 1.0.4 and 1.0.1 respectively.</p></li>
 </ol>
 </div>
-<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.1.2</a></h2>
+<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.1.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Extended <b class="cmd">critcl::cproc</b> to be able to handle optional
@@ -764,7 +780,7 @@ paragraph.</p>
        emulation package <b class="package">lassign84</b> to 1.0.1.</p></li>
 </ol>
 </div>
-<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.1.1</a></h2>
+<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.1.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed the generation of wrong#args errors for
@@ -778,7 +794,7 @@ separators. Bumped to version 1.0.1.</p></li>
 instance creation for clarity. Bumped to version 1.0.2.</p></li>
 </ol>
 </div>
-<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.1</a></h2>
+<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Added a new higher-level package <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p>
 <p>This package simplifies the creation of code associating data
@@ -837,7 +853,7 @@ define custom argument and result types for <b class="cmd">::critcl::cproc</b>.<
 details of the provided commands.</p></li>
 </ol>
 </div>
-<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.0.7</a></h2>
+<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3.0.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed the code generated by <b class="cmd">critcl::c++command</b>.
         The emitted code handed a non-static string table to
@@ -847,7 +863,7 @@ details of the provided commands.</p></li>
 	us to the general problem.</p></li>
 </ol>
 </div>
-<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3.0.6</a></h2>
+<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 3.0.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issue 10. The critcl application now delivers a
 	proper exit code (1) on build failure, instead of always
@@ -860,7 +876,7 @@ details of the provided commands.</p></li>
 	the README.md shown by github</p></li>
 </ol>
 </div>
-<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 3.0.5</a></h2>
+<div id="section33" class="doctools_section"><h2><a name="section33">Changes for version 3.0.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug in the new code for #line pragmas triggered when
 	specifying C code without leading whitespace.</p></li>
@@ -868,7 +884,7 @@ details of the provided commands.</p></li>
 	source retrieval, installer, and developer's guides.</p></li>
 </ol>
 </div>
-<div id="section33" class="doctools_section"><h2><a name="section33">Changes for version 3.0.4</a></h2>
+<div id="section34" class="doctools_section"><h2><a name="section34">Changes for version 3.0.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed generation of the package's initname when the incoming
 	code is read from stdin and has no proper path.</p></li>
@@ -898,7 +914,7 @@ details of the provided commands.</p></li>
 	release.</p></li>
 </ol>
 </div>
-<div id="section34" class="doctools_section"><h2><a name="section34">Changes for version 3.0.3</a></h2>
+<div id="section35" class="doctools_section"><h2><a name="section35">Changes for version 3.0.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issues 5 and 8, for the example build.tcl
 scripts. Working around a missing variable ::errorInfo. It should
@@ -906,7 +922,7 @@ always be present, however there seem to be revisions of Tcl around
 which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section35" class="doctools_section"><h2><a name="section35">Changes for version 3.0.2</a></h2>
+<div id="section36" class="doctools_section"><h2><a name="section36">Changes for version 3.0.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue in compile-and-run mode where commands put into the
 auto_index are not found by Tcl's [unknown] command.</p></li>
@@ -919,7 +935,7 @@ option <b class="option">-I</b>, just for library search paths.</p></li>
 revisions of Tcl around which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section36" class="doctools_section"><h2><a name="section36">Changes for version 3.0.1</a></h2>
+<div id="section37" class="doctools_section"><h2><a name="section37">Changes for version 3.0.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed recording of Tcl version requirements. Keep package name
@@ -950,7 +966,7 @@ for the library in the paths specified by the environment variable
 LIB.</p></li>
 </ol>
 </div>
-<div id="section37" class="doctools_section"><h2><a name="section37">Changes for version 3</a></h2>
+<div id="section38" class="doctools_section"><h2><a name="section38">Changes for version 3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>The command <b class="cmd">critcl::platform</b> was deprecated in version
 2.1, superceded by <b class="cmd">critcl::targetplatform</b>, yet kept for
@@ -1017,7 +1033,7 @@ for/about the package.</p>
 <b class="package"><a href="critcl_pkg.html">critcl</a></b> package documentation for details.</p></li>
 </ol>
 </div>
-<div id="section38" class="doctools_section"><h2><a name="section38">Changes for version 2.1</a></h2>
+<div id="section39" class="doctools_section"><h2><a name="section39">Changes for version 2.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug where <b class="cmd">critcl::tsources</b> interpreted relative
 paths as relative to the current working directory instead of
@@ -1114,10 +1130,10 @@ still using proper path names and init function.</p></li>
 <li><p>Dropped remnants of support for Tcl 8.3 and before.</p></li>
 </ol>
 </div>
-<div id="section39" class="doctools_section"><h2><a name="section39">Authors</a></h2>
+<div id="section40" class="doctools_section"><h2><a name="section40">Authors</a></h2>
 <p>Jean Claude Wippler, Steve Landers, Andreas Kupries</p>
 </div>
-<div id="section40" class="doctools_section"><h2><a name="section40">Bugs, Ideas, Feedback</a></h2>
+<div id="section41" class="doctools_section"><h2><a name="section41">Bugs, Ideas, Feedback</a></h2>
 <p>This document, and the package it describes, will undoubtedly contain
 bugs and other problems.
 Please report them at <a href="https://github.com/andreas-kupries/critcl/issues">https://github.com/andreas-kupries/critcl/issues</a>.

--- a/embedded/www/files/critcl_pkg.html
+++ b/embedded/www/files/critcl_pkg.html
@@ -2404,11 +2404,11 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 <p>Moved the command activating more precise code location
        tracking out of package <b class="package">critcl</b> into package
        <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
-<p>The ahead of time compilation of the <i class="term">package</i> mode done
-       by the application (package) can bear the performance penalty
-       invoked by this <em>global</em> setting.</p>
-<p>Arbitrary libraries and applications using critcl dynamically,
-       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+<p>Because generating packages ahead of time can bear the
+       performance penalty invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically
+       (<i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>) on the other hand likely cannot, and
+       should not.</p></li>
 </ol>
 </div>
 <div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.18.1</a></h2>

--- a/embedded/www/files/critcl_pkg.html
+++ b/embedded/www/files/critcl_pkg.html
@@ -102,7 +102,7 @@
 &#124; <a href="../index.html">Keyword Index</a>
  ] <hr>
 <div class="doctools">
-<h1 class="doctools_title">critcl(n) 3.1.18 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
+<h1 class="doctools_title">critcl(n) 3.1.18.2 doc &quot;C Runtime In Tcl (CriTcl)&quot;</h1>
 <div id="name" class="doctools_section"><h2><a name="name">Name</a></h2>
 <p>critcl - CriTcl - Package Reference</p>
 </div>
@@ -142,37 +142,38 @@
 </ul>
 </li>
 <li class="doctools_section"><a href="#section4">Examples</a></li>
-<li class="doctools_section"><a href="#section5">Changes for version 3.1.18.1</a></li>
-<li class="doctools_section"><a href="#section6">Changes for version 3.1.18</a></li>
-<li class="doctools_section"><a href="#section7">Changes for version 3.1.17</a></li>
-<li class="doctools_section"><a href="#section8">Changes for version 3.1.16</a></li>
-<li class="doctools_section"><a href="#section9">Changes for version 3.1.15</a></li>
-<li class="doctools_section"><a href="#section10">Changes for version 3.1.14</a></li>
-<li class="doctools_section"><a href="#section11">Changes for version 3.1.13</a></li>
-<li class="doctools_section"><a href="#section12">Changes for version 3.1.12</a></li>
-<li class="doctools_section"><a href="#section13">Changes for version 3.1.11</a></li>
-<li class="doctools_section"><a href="#section14">Changes for version 3.1.10</a></li>
-<li class="doctools_section"><a href="#section15">Changes for version 3.1.9</a></li>
-<li class="doctools_section"><a href="#section16">Changes for version 3.1.8</a></li>
-<li class="doctools_section"><a href="#section17">Changes for version 3.1.7</a></li>
-<li class="doctools_section"><a href="#section18">Changes for version 3.1.6</a></li>
-<li class="doctools_section"><a href="#section19">Changes for version 3.1.5</a></li>
-<li class="doctools_section"><a href="#section20">Changes for version 3.1.4</a></li>
-<li class="doctools_section"><a href="#section21">Changes for version 3.1.3</a></li>
-<li class="doctools_section"><a href="#section22">Changes for version 3.1.2</a></li>
-<li class="doctools_section"><a href="#section23">Changes for version 3.1.1</a></li>
-<li class="doctools_section"><a href="#section24">Changes for version 3.1</a></li>
-<li class="doctools_section"><a href="#section25">Changes for version 3.0.7</a></li>
-<li class="doctools_section"><a href="#section26">Changes for version 3.0.6</a></li>
-<li class="doctools_section"><a href="#section27">Changes for version 3.0.5</a></li>
-<li class="doctools_section"><a href="#section28">Changes for version 3.0.4</a></li>
-<li class="doctools_section"><a href="#section29">Changes for version 3.0.3</a></li>
-<li class="doctools_section"><a href="#section30">Changes for version 3.0.2</a></li>
-<li class="doctools_section"><a href="#section31">Changes for version 3.0.1</a></li>
-<li class="doctools_section"><a href="#section32">Changes for version 3</a></li>
-<li class="doctools_section"><a href="#section33">Changes for version 2.1</a></li>
-<li class="doctools_section"><a href="#section34">Authors</a></li>
-<li class="doctools_section"><a href="#section35">Bugs, Ideas, Feedback</a></li>
+<li class="doctools_section"><a href="#section5">Changes for version 3.1.18.2</a></li>
+<li class="doctools_section"><a href="#section6">Changes for version 3.1.18.1</a></li>
+<li class="doctools_section"><a href="#section7">Changes for version 3.1.18</a></li>
+<li class="doctools_section"><a href="#section8">Changes for version 3.1.17</a></li>
+<li class="doctools_section"><a href="#section9">Changes for version 3.1.16</a></li>
+<li class="doctools_section"><a href="#section10">Changes for version 3.1.15</a></li>
+<li class="doctools_section"><a href="#section11">Changes for version 3.1.14</a></li>
+<li class="doctools_section"><a href="#section12">Changes for version 3.1.13</a></li>
+<li class="doctools_section"><a href="#section13">Changes for version 3.1.12</a></li>
+<li class="doctools_section"><a href="#section14">Changes for version 3.1.11</a></li>
+<li class="doctools_section"><a href="#section15">Changes for version 3.1.10</a></li>
+<li class="doctools_section"><a href="#section16">Changes for version 3.1.9</a></li>
+<li class="doctools_section"><a href="#section17">Changes for version 3.1.8</a></li>
+<li class="doctools_section"><a href="#section18">Changes for version 3.1.7</a></li>
+<li class="doctools_section"><a href="#section19">Changes for version 3.1.6</a></li>
+<li class="doctools_section"><a href="#section20">Changes for version 3.1.5</a></li>
+<li class="doctools_section"><a href="#section21">Changes for version 3.1.4</a></li>
+<li class="doctools_section"><a href="#section22">Changes for version 3.1.3</a></li>
+<li class="doctools_section"><a href="#section23">Changes for version 3.1.2</a></li>
+<li class="doctools_section"><a href="#section24">Changes for version 3.1.1</a></li>
+<li class="doctools_section"><a href="#section25">Changes for version 3.1</a></li>
+<li class="doctools_section"><a href="#section26">Changes for version 3.0.7</a></li>
+<li class="doctools_section"><a href="#section27">Changes for version 3.0.6</a></li>
+<li class="doctools_section"><a href="#section28">Changes for version 3.0.5</a></li>
+<li class="doctools_section"><a href="#section29">Changes for version 3.0.4</a></li>
+<li class="doctools_section"><a href="#section30">Changes for version 3.0.3</a></li>
+<li class="doctools_section"><a href="#section31">Changes for version 3.0.2</a></li>
+<li class="doctools_section"><a href="#section32">Changes for version 3.0.1</a></li>
+<li class="doctools_section"><a href="#section33">Changes for version 3</a></li>
+<li class="doctools_section"><a href="#section34">Changes for version 2.1</a></li>
+<li class="doctools_section"><a href="#section35">Authors</a></li>
+<li class="doctools_section"><a href="#section36">Bugs, Ideas, Feedback</a></li>
 <li class="doctools_section"><a href="#keywords">Keywords</a></li>
 <li class="doctools_section"><a href="#category">Category</a></li>
 <li class="doctools_section"><a href="#copyright">Copyright</a></li>
@@ -182,7 +183,7 @@
 <div class="doctools_synopsis">
 <ul class="doctools_requirements">
 <li>package require <b class="pkgname">Tcl 8.4</b></li>
-<li>package require <b class="pkgname">critcl <span class="opt">?3.1.18?</span></b></li>
+<li>package require <b class="pkgname">critcl <span class="opt">?3.1.18.2?</span></b></li>
 <li>package require <b class="pkgname">platform <span class="opt">?1.0.2?</span></b></li>
 <li>package require <b class="pkgname">md5 <span class="opt">?2?</span></b></li>
 </ul>
@@ -2395,7 +2396,22 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 <p>See section &quot;Embedding C&quot; in <i class="term"><a href="critcl_usingit.html">Using CriTcl</a></i>.</p>
 <p>The latest changes are found at the top.</p>
 </div>
-<div id="section5" class="doctools_section"><h2><a name="section5">Changes for version 3.1.18.1</a></h2>
+<div id="section5" class="doctools_section"><h2><a name="section5">Changes for version 3.1.18.2</a></h2>
+<p><em>Not Released Yet</em></p>
+<ol class="doctools_enumerated">
+<li><p><em>Performance Fix</em> for <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> mode.
+       Issue #112.</p>
+<p>Moved the command activating more precise code location
+       tracking out of package <b class="package">critcl</b> into package
+       <b class="package"><a href="critcl_apppkg.html">critcl::app</a></b>.</p>
+<p>The ahead of time compilation of the <i class="term">package</i> mode done
+       by the application (package) can bear the performance penalty
+       invoked by this <em>global</em> setting.</p>
+<p>Arbitrary libraries and applications using critcl dynamically,
+       i.e. in <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i> likely cannot, and should not.</p></li>
+</ol>
+</div>
+<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.18.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p><em>Attention</em>: While the overall version (of the bundle)
        moves to 3.1.18.1 the versions of packages <b class="package">critcl</b> and
@@ -2408,7 +2424,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        compilation of the generated code.</p></li>
 </ol>
 </div>
-<div id="section6" class="doctools_section"><h2><a name="section6">Changes for version 3.1.18</a></h2>
+<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.18</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Feature (Developer support). Merged pull request #96 from
        sebres/main-direct-invoke. Enables direct invokation of the
@@ -2486,7 +2502,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 <p>See the package reference for the details.</p></li>
 </ol>
 </div>
-<div id="section7" class="doctools_section"><h2><a name="section7">Changes for version 3.1.17</a></h2>
+<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.17</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Extension: Allow duplicate arg- and result-type definitions if
        they are fully identical.</p></li>
@@ -2538,7 +2554,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        default. Both modes can be used together.</p></li>
 </ol>
 </div>
-<div id="section8" class="doctools_section"><h2><a name="section8">Changes for version 3.1.16</a></h2>
+<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.16</a></h2>
 <ol class="doctools_enumerated">
 <li><p>New feature. Extended <b class="cmd">critcl::cproc</b>'s argument handling
        to allow arbitrary mixing of required and optional arguments.</p></li>
@@ -2584,12 +2600,12 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        is limited to mode <i class="term"><a href="../index.html#compile_run">compile &amp; run</a></i>.</p></li>
 </ol>
 </div>
-<div id="section9" class="doctools_section"><h2><a name="section9">Changes for version 3.1.15</a></h2>
+<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.15</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed version number bogosity with <b class="const">3.1.14</b>.</p></li>
 </ol>
 </div>
-<div id="section10" class="doctools_section"><h2><a name="section10">Changes for version 3.1.14</a></h2>
+<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.14</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #36. Added message to target <b class="const">all</b> of the
         Makefile generated for TEA mode. Additionally tweaked other
@@ -2619,7 +2635,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
         location of the troubling declaration.</p></li>
 </ol>
 </div>
-<div id="section11" class="doctools_section"><h2><a name="section11">Changes for version 3.1.13</a></h2>
+<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.13</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Merged PR #43. Fixed bug loading adjunct Tcl sources.</p></li>
 <li><p>Fixes in documentation and generated code of package
@@ -2670,7 +2686,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 	a fix as they are all built on top of &quot;iassoc&quot;.</p></li>
 </ol>
 </div>
-<div id="section12" class="doctools_section"><h2><a name="section12">Changes for version 3.1.12</a></h2>
+<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.12</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue 42. Clear ::errorInfo immediately after startup to
        prevent leakage of irrelevant (caught) errors into our script
@@ -2695,7 +2711,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 	<b class="package"><a href="critcl_enum.html">critcl::enum</a></b></p></li>
 </ol>
 </div>
-<div id="section13" class="doctools_section"><h2><a name="section13">Changes for version 3.1.11</a></h2>
+<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.11</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #37, via pull request #38, with thanks to
        Jos DeCoster. Information was stored into the v::delproc
@@ -2715,7 +2731,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        Built on top of <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p></li>
 </ol>
 </div>
-<div id="section14" class="doctools_section"><h2><a name="section14">Changes for version 3.1.10</a></h2>
+<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.10</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed code version numbering forgotten with 3.1.9.</p></li>
 <li><p>Fixed issue #35. In package mode (-pkg) the object cache
@@ -2731,7 +2747,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 	sources. Bug and fix reported by Peter Spjuth.</p></li>
 </ol>
 </div>
-<div id="section15" class="doctools_section"><h2><a name="section15">Changes for version 3.1.9</a></h2>
+<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.9</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #27. Added missing platform definitions for
 	various alternate linux and OS X targets.</p></li>
@@ -2755,7 +2771,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 <li><p>Fixed issue #34. Handle files starting with a dot better.</p></li>
 </ol>
 </div>
-<div id="section16" class="doctools_section"><h2><a name="section16">Changes for version 3.1.8</a></h2>
+<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.8</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue with package indices generated for Tcl 8.4.
 	Join the list of commands with semi-colon, not newline.</p></li>
@@ -2763,7 +2779,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 	consider while fixing bug #21 (see critcl 3.1.6).</p></li>
 </ol>
 </div>
-<div id="section17" class="doctools_section"><h2><a name="section17">Changes for version 3.1.7</a></h2>
+<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #24. Extract and unconditionally display compiler
 	warnings found in the build log. Prevents users from missing
@@ -2776,7 +2792,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 	inherit values from configurations defined before them.</p></li>
 </ol>
 </div>
-<div id="section18" class="doctools_section"><h2><a name="section18">Changes for version 3.1.6</a></h2>
+<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #21. While the multi-definition of the stub-table
        pointer variables was ok with for all the C linkers seen so far
@@ -2798,7 +2814,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
 <li><p>Fixed issue #23.</p></li>
 </ol>
 </div>
-<div id="section19" class="doctools_section"><h2><a name="section19">Changes for version 3.1.5</a></h2>
+<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue #19. Made the regular expression extracting the
        MSVC version number more general to make it work on german
@@ -2808,7 +2824,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        a unix emulation environment like msys/mingw.</p></li>
 </ol>
 </div>
-<div id="section20" class="doctools_section"><h2><a name="section20">Changes for version 3.1.4</a></h2>
+<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfix in package <b class="package"><a href="critcl_class.html">critcl::class</a></b>. Generate a dummy
        field in the class structure if the class has no class
@@ -2819,7 +2835,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        <b class="cmd"><a href="critcl_class.html">critcl::class</a></b>.</p></li>
 </ol>
 </div>
-<div id="section21" class="doctools_section"><h2><a name="section21">Changes for version 3.1.3</a></h2>
+<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Added new argument type &quot;pstring&quot;, for &quot;Pascal String&quot;, a
@@ -2835,7 +2851,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        Versions bumped to 1.0.4 and 1.0.1 respectively.</p></li>
 </ol>
 </div>
-<div id="section22" class="doctools_section"><h2><a name="section22">Changes for version 3.1.2</a></h2>
+<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Enhancement. In detail:</p></li>
 <li><p>Extended <b class="cmd">critcl::cproc</b> to be able to handle optional
@@ -2846,7 +2862,7 @@ Rng_InitStubs(Tcl_Interp *interp, CONST char *version, int exact)
        emulation package <b class="package">lassign84</b> to 1.0.1.</p></li>
 </ol>
 </div>
-<div id="section23" class="doctools_section"><h2><a name="section23">Changes for version 3.1.1</a></h2>
+<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.1.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed the generation of wrong#args errors for
@@ -2860,7 +2876,7 @@ separators. Bumped to version 1.0.1.</p></li>
 instance creation for clarity. Bumped to version 1.0.2.</p></li>
 </ol>
 </div>
-<div id="section24" class="doctools_section"><h2><a name="section24">Changes for version 3.1</a></h2>
+<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Added a new higher-level package <b class="package"><a href="critcl_iassoc.html">critcl::iassoc</a></b>.</p>
 <p>This package simplifies the creation of code associating data
@@ -2919,7 +2935,7 @@ define custom argument and result types for <b class="cmd">::critcl::cproc</b>.<
 details of the provided commands.</p></li>
 </ol>
 </div>
-<div id="section25" class="doctools_section"><h2><a name="section25">Changes for version 3.0.7</a></h2>
+<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.0.7</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed the code generated by <b class="cmd">critcl::c++command</b>.
         The emitted code handed a non-static string table to
@@ -2929,7 +2945,7 @@ details of the provided commands.</p></li>
 	us to the general problem.</p></li>
 </ol>
 </div>
-<div id="section26" class="doctools_section"><h2><a name="section26">Changes for version 3.0.6</a></h2>
+<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.6</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issue 10. The critcl application now delivers a
 	proper exit code (1) on build failure, instead of always
@@ -2942,7 +2958,7 @@ details of the provided commands.</p></li>
 	the README.md shown by github</p></li>
 </ol>
 </div>
-<div id="section27" class="doctools_section"><h2><a name="section27">Changes for version 3.0.5</a></h2>
+<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.5</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug in the new code for #line pragmas triggered when
 	specifying C code without leading whitespace.</p></li>
@@ -2950,7 +2966,7 @@ details of the provided commands.</p></li>
 	source retrieval, installer, and developer's guides.</p></li>
 </ol>
 </div>
-<div id="section28" class="doctools_section"><h2><a name="section28">Changes for version 3.0.4</a></h2>
+<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.0.4</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed generation of the package's initname when the incoming
 	code is read from stdin and has no proper path.</p></li>
@@ -2980,7 +2996,7 @@ details of the provided commands.</p></li>
 	release.</p></li>
 </ol>
 </div>
-<div id="section29" class="doctools_section"><h2><a name="section29">Changes for version 3.0.3</a></h2>
+<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.0.3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed github issues 5 and 8, for the example build.tcl
 scripts. Working around a missing variable ::errorInfo. It should
@@ -2988,7 +3004,7 @@ always be present, however there seem to be revisions of Tcl around
 which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section30" class="doctools_section"><h2><a name="section30">Changes for version 3.0.2</a></h2>
+<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3.0.2</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed issue in compile-and-run mode where commands put into the
 auto_index are not found by Tcl's [unknown] command.</p></li>
@@ -3001,7 +3017,7 @@ option <b class="option">-I</b>, just for library search paths.</p></li>
 revisions of Tcl around which violate this assumption.</p></li>
 </ol>
 </div>
-<div id="section31" class="doctools_section"><h2><a name="section31">Changes for version 3.0.1</a></h2>
+<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 3.0.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Bugfixes all around. In detail:</p></li>
 <li><p>Fixed recording of Tcl version requirements. Keep package name
@@ -3032,7 +3048,7 @@ for the library in the paths specified by the environment variable
 LIB.</p></li>
 </ol>
 </div>
-<div id="section32" class="doctools_section"><h2><a name="section32">Changes for version 3</a></h2>
+<div id="section33" class="doctools_section"><h2><a name="section33">Changes for version 3</a></h2>
 <ol class="doctools_enumerated">
 <li><p>The command <b class="cmd">critcl::platform</b> was deprecated in version
 2.1, superceded by <b class="cmd">critcl::targetplatform</b>, yet kept for
@@ -3099,7 +3115,7 @@ for/about the package.</p>
 <b class="package">critcl</b> package documentation for details.</p></li>
 </ol>
 </div>
-<div id="section33" class="doctools_section"><h2><a name="section33">Changes for version 2.1</a></h2>
+<div id="section34" class="doctools_section"><h2><a name="section34">Changes for version 2.1</a></h2>
 <ol class="doctools_enumerated">
 <li><p>Fixed bug where <b class="cmd">critcl::tsources</b> interpreted relative
 paths as relative to the current working directory instead of
@@ -3196,10 +3212,10 @@ still using proper path names and init function.</p></li>
 <li><p>Dropped remnants of support for Tcl 8.3 and before.</p></li>
 </ol>
 </div>
-<div id="section34" class="doctools_section"><h2><a name="section34">Authors</a></h2>
+<div id="section35" class="doctools_section"><h2><a name="section35">Authors</a></h2>
 <p>Jean Claude Wippler, Steve Landers, Andreas Kupries</p>
 </div>
-<div id="section35" class="doctools_section"><h2><a name="section35">Bugs, Ideas, Feedback</a></h2>
+<div id="section36" class="doctools_section"><h2><a name="section36">Bugs, Ideas, Feedback</a></h2>
 <p>This document, and the package it describes, will undoubtedly contain
 bugs and other problems.
 Please report them at <a href="https://github.com/andreas-kupries/critcl/issues">https://github.com/andreas-kupries/critcl/issues</a>.

--- a/lib/app-critcl/critcl.tcl
+++ b/lib/app-critcl/critcl.tcl
@@ -33,6 +33,22 @@ package require cmdline
 namespace eval ::critcl::app {}
 
 # # ## ### ##### ######## ############# #####################
+## https://github.com/andreas-kupries/critcl/issues/112
+## Ensure that we have maximal 'info frame' data, if supported
+#
+## ATTENTION: This slows the Tcl core down by about 10%, sometimes
+## more, due to the need to track location information in some
+## critical paths of Tcl_Obj management.
+#
+## I am willing to pay that price here, because this is isolated to
+## the operation of the critcl application itself. While some more
+## time is spent in the ahead-of-time compilation the result is not
+## affected. And I want the more precise location information for when
+## compilation fails.
+
+catch { interp debug {} -frame 1 }
+
+# # ## ### ##### ######## ############# #####################
 ## Intercept 'package' calls.
 #
 # This code is present to handle the possibility of building multiple

--- a/lib/critcl/pkgIndex.tcl
+++ b/lib/critcl/pkgIndex.tcl
@@ -1,1 +1,1 @@
-package ifneeded critcl 3.1.18 [list source [file join $dir critcl.tcl]]
+package ifneeded critcl 3.1.18.2 [list source [file join $dir critcl.tcl]]


### PR DESCRIPTION
Moved the command / global setting responsible to the critcl
application. This can bear the price, and the effect is isolated.

Bumped critcl and application packages to version 3.1.18.2.