### PR TITLE
Pass clibraries paths to libdl via LD_LIBRARY_PATH, SHLIB_PATH

### DIFF
--- a/lib/app-critcl/critcl.tcl
+++ b/lib/app-critcl/critcl.tcl
@@ -6,12 +6,14 @@
 
 # # ## ### ##### ######## ############# #####################
 
-#   Prebuild shared libraries using the Critcl package.
+# Prebuild shared libraries using the Critcl package.
 #
 #   Based originally on critbind by Jean-Claude Wippler
 #   Transmogrified into critcl   by Steve Landers
 #
-#   $Id: critcl.tcl 4717 2009-11-02 01:24:42Z stevel $
+# Copyright (c) 2001-20?? Jean-Claude Wippler
+# Copyright (c) 2002-20?? Steve Landers
+# Copyright (c) 20??-2022 Andreas Kupries <andreas_kupries@users.sourceforge.net>
 #
 # \
     exec tclkit $0 ${1+"$@"}
@@ -183,6 +185,8 @@ proc ::critcl::app::main {argv} {
     if {$v::keep} {
 	::critcl::print stderr "Files left in [critcl::cache]"
     }
+
+    ::critcl::print "Done\n"
     return
 }
 
@@ -921,7 +925,7 @@ proc ::critcl::app::ExportHeaders {} {
 	set stem [file tail $dir]
 	set dst  [file join $incdir $stem]
 
-	::critcl::print "Headers:  $v::incdir/$stem"
+	::critcl::print "Headers Placed Into: $v::incdir/$stem"
 
 	file mkdir $dst
 	foreach f [glob -nocomplain -directory $dir *] {
@@ -956,7 +960,7 @@ proc ::critcl::app::AssemblePackage {} {
     } else {
 	set dir $pkgdir
     }
-    ::critcl::print "Package:  $dir"
+    ::critcl::print "\nPackage Placed Into: $dir"
 
     file mkdir             $pkgdir
     file mkdir             $shlibdir

--- a/lib/app-critcl/critcl.tcl
+++ b/lib/app-critcl/critcl.tcl
@@ -932,12 +932,16 @@ proc ::critcl::app::ExportHeaders {} {
 }
 
 proc ::critcl::app::AssemblePackage {} {
-
     # Validate and/or create the main destination directory L. The
     # package will become a subdirectory of L. See (x). And a platform
     # specific directory inside of that will hold the shared
     # library. This allows us to later merge the packages for
     # different platforms into a single multi-platform package.
+
+    if {![llength $v::pkgs]} {
+	::critcl::print stderr "ERROR: `package provide` missing in package sources"
+	exit 1
+    }
 
     set libdir [CreateLibDirectory]
 

--- a/lib/critcl/Config
+++ b/lib/critcl/Config
@@ -70,6 +70,7 @@ ldoutput
 link_debug
 link_release
 link_preload    --unresolved-symbols=ignore-in-shared-libs
+link_rpath      -Wl,-rpath,@
 strip           -Wl,-s
 optimize        -O2
 noassert        -DNDEBUG

--- a/lib/critcl/Config
+++ b/lib/critcl/Config
@@ -368,6 +368,7 @@ win32-ix86-cl  ldoutput        -dll [list -out:$outfile]
 win32-ix86-cl  link_debug      $msvclinkdebug -debugtype:cv -verbose:lib -nodefaultlib:libc
 win32-ix86-cl  link_release    -release -opt:ref -opt:icf,3 $msvclinkworkingset  -verbose:lib $msvclinkglobaloptimize
 win32-ix86-cl  link_preload
+win32-ix86-cl  link_rpath
 win32-ix86-cl  strip
 win32-ix86-cl  version         cl
 win32-ix86-cl  platform        win32-ix86

--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -3943,6 +3943,8 @@ proc ::critcl::SetParam {type values {expand 1} {uuid 0} {unique 0}} {
 
     UUID.extend $file .$type $values
 
+    msg "\t$type += $values"
+
     # Process the list of flags, treat non-option arguments as glob
     # patterns and expand them to a set of files, stored as absolute
     # paths.
@@ -4598,6 +4600,7 @@ proc ::critcl::Link {file} {
 	set opt [getconfigvalue link_rpath]
 	if {$opt ne {}} {
 	    foreach path $libpaths {
+		msg "\trpath += $path"
 		lappend cmdline [string map [list @ $path] $opt]
 	    }
 	}

--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -3945,7 +3945,7 @@ proc ::critcl::SetParam {type values {expand 1} {uuid 0} {unique 0}} {
 
     UUID.extend $file .$type $values
 
-    msg "\t$type += $values"
+    #todo (debug flag): msg "\t$type += $values"
 
     # Process the list of flags, treat non-option arguments as glob
     # patterns and expand them to a set of files, stored as absolute
@@ -4602,7 +4602,7 @@ proc ::critcl::Link {file} {
 	set opt [getconfigvalue link_rpath]
 	if {$opt ne {}} {
 	    foreach path $libpaths {
-		msg "\trpath += $path"
+		# todo (debug flag) msg "\trpath += $path"
 		lappend cmdline [string map [list @ $path] $opt]
 	    }
 	}
@@ -5304,7 +5304,7 @@ proc ::critcl::Exec {cmdline} {
 proc ::critcl::ExecWithLogging {cmdline okmsg errmsg} {
     variable run
 
-    msg        "EXEC: $cmdline"
+    # todo (debug flag) msg "EXEC: $cmdline"
     LogCmdline $cmdline
 
     # Extend the command, redirect all of its output (stdout and

--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -4596,8 +4596,10 @@ proc ::critcl::Link {file} {
     set libpaths [dict get $v::code($file) result libpaths]
     if {[llength $libpaths]} {
 	set opt [getconfigvalue link_rpath]
-	foreach path $libpaths {
-	    lappend cmdline [string map [list @ $path] $opt]
+	if {$opt ne {}} {
+	    foreach path $libpaths {
+		lappend cmdline [string map [list @ $path] $opt]
+	    }
 	}
     }
 

--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -5304,6 +5304,7 @@ proc ::critcl::Exec {cmdline} {
 proc ::critcl::ExecWithLogging {cmdline okmsg errmsg} {
     variable run
 
+    msg        "EXEC: $cmdline"
     LogCmdline $cmdline
 
     # Extend the command, redirect all of its output (stdout and

--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2001-20?? Jean-Claude Wippler
 # Copyright (c) 2002-20?? Steve Landers
-# Copyright (c) 20??-2017 Andreas Kupries <andreas_kupries@users.sourceforge.net>
+# Copyright (c) 20??-2022 Andreas Kupries <andreas_kupries@users.sourceforge.net>
 
 # # ## ### ##### ######## ############# #####################
 # CriTcl Core.

--- a/lib/critcl/critcl.tcl
+++ b/lib/critcl/critcl.tcl
@@ -3943,47 +3943,45 @@ proc ::critcl::SetParam {type values {expand 1} {uuid 0} {unique 0}} {
 
     UUID.extend $file .$type $values
 
-    if {[llength $values]} {
-	# Process the list of flags, treat non-option arguments as
-	# glob patterns and expand them to a set of files, stored as
-	# absolute paths.
+    # Process the list of flags, treat non-option arguments as glob
+    # patterns and expand them to a set of files, stored as absolute
+    # paths.
 
-	set have {}
-	if {$unique && [dict exists $v::code($file) config $type]} {
-	    foreach v [dict get $v::code($file) config $type] {
-		dict set have $v .
-	    }
+    set have {}
+    if {$unique && [dict exists $v::code($file) config $type]} {
+	foreach v [dict get $v::code($file) config $type] {
+	    dict set have $v .
 	}
-
-	set tmp {}
-	foreach v $values {
-	    if {[string match "-*" $v]} {
-		lappend tmp $v
-	    } else {
-		if {$expand} {
-		    foreach f [Expand $file $v] {
-			if {$unique && [dict exists $have $f]} continue
-			lappend tmp $f
-			if {$unique} { dict set have $f . }
-			if {$uuid} { UUID.extend $file .$type.$f [Cat $f] }
-		    }
-		} else {
-		    if {$unique && [dict exists $have $v]} continue
-		    lappend tmp $v
-		    if {$unique} { dict set have $v . }
-		}
-	    }
-	}
-
-	# And save into the system state.
-	dict update v::code($file) config c {
-	    foreach v $tmp {
-		dict lappend c $type $v
-	    }
-	}
-    } elseif {[dict exists $v::code($file) config $type]} {
-	return [dict get $v::code($file) config $type]
     }
+
+    set tmp {}
+    foreach v $values {
+	if {[string match "-*" $v]} {
+	    lappend tmp $v
+	} else {
+	    if {$expand} {
+		foreach f [Expand $file $v] {
+		    if {$unique && [dict exists $have $f]} continue
+		    lappend tmp $f
+		    if {$unique} { dict set have $f . }
+		    if {$uuid} { UUID.extend $file .$type.$f [Cat $f] }
+		}
+	    } else {
+		if {$unique && [dict exists $have $v]} continue
+		lappend tmp $v
+		if {$unique} { dict set have $v . }
+	    }
+	}
+    }
+
+    # And save into the system state.
+    dict update v::code($file) config c {
+	foreach v $tmp {
+	    dict lappend c $type $v
+	}
+    }
+
+    return
 }
 
 proc ::critcl::Expand {file pattern} {


### PR DESCRIPTION
fix #121 

Pass clibrary paths to loader for extended search
Both for compile and run, and generated package (via index).

Deeper testing to be done tomorrow. Right now only willing to admit that the paths indeed appear in what I believe to be the correct places. Needs however proper testing with actual non-standard path and a shlib there.
