### PR TITLE
Ensure that the build script exits with a non-zero status when there …

### DIFF
--- a/build.tcl
+++ b/build.tcl
@@ -41,7 +41,7 @@ proc usage {{status 1}} {
 	![string match {invalid command name "_*"*} $errorInfo]
     } {
 	puts stderr $::errorInfo
-	exit
+	exit $status
     }
 
     global argv0


### PR DESCRIPTION
This is a minor one-line change that simply ensures that the interpreter exits with a non-zero status when there is an error.  Without this change, any automated process that depends on the exit status to determine success may falsely report success, which could for example lead to a case where critcl is reported to be successfully installed when in fact it is not.