### PR TITLE
Support macOS 26 and later versioning convention

### DIFF
--- a/lib/app-critcl/runtime.tcl
+++ b/lib/app-critcl/runtime.tcl
@@ -118,9 +118,12 @@ proc ::critcl::runtime::MapPlatform {{mapping {}}} {
 	set v1 [lindex $v 0]
 	set v2 [lindex $v 1]
 	set v3 [lindex $v 2]
-	# Darwin 19 and earlier are macOS 10.x. Darwin 20 and later are macOS
-    # 11, macOS 12, etc.
-    if {$v1 >= 20} {
+    # Darwin 19 and earlier are macOS 10.x. Darwin 20-24 are macOS
+    # 11-15. Darwin 25 is macOS 26.
+    if {$v1 >= 25} {
+        incr v1
+        set version $v1.$v2.$v3
+    } elseif {$v1 >= 20} {
         incr v1 -9
         set version $v1.$v2.$v3
     } else {

--- a/lib/critcl-platform/platform.tcl
+++ b/lib/critcl-platform/platform.tcl
@@ -183,14 +183,17 @@ proc ::platform::identify {} {
 	macosx {
 	    set major [lindex [split $tcl_platform(osVersion) .] 0]
 	    if {$major > 8} {
-	        # Darwin 19 and earlier are macOS 10.x. Darwin 20 and later
-            # are macOS 11, macOS 12, etc.
-	        if {$major >= 20} {
+	        # Darwin 19 and earlier are macOS 10.x. Darwin 20-24
+	        # are macOS 11-15. Darwin 25 is macOS 26.
+	        if {$major >= 25} {
+	            incr major
+	            append plat $major
+	        } elseif {$major >= 20} {
 	            incr major -9
-		        append plat $major
+	            append plat $major
 	        } else {
 	            incr major -4
-		        append plat 10.$major
+	            append plat 10.$major
 	        }
 		    return "${plat}-${cpu}"
 	    }

--- a/lib/critcl/Config
+++ b/lib/critcl/Config
@@ -146,9 +146,12 @@ if {[string match macosx-* $platform]} {
     } else {
         # use the current platform
         foreach {v1 v2 v3} [split $::tcl_platform(osVersion) .] break
-        # Darwin 19 and earlier are macOS 10.x. Darwin 20 and later are macOS
-        # 11, macOS 12, etc.
-        if {$v1 >= 20} {
+        # Darwin 19 and earlier are macOS 10.x. Darwin 20-24 are macOS
+        # 11-15. Darwin 25 is macOS 26.
+        if {$v1 >= 25} {
+            incr v1
+            set osxmin ${v1}.0
+        } elseif {$v1 >= 20} {
             incr v1 -9
             set osxmin ${v1}.0
         } else {


### PR DESCRIPTION
With macOS 26, Apple has yet again changed the way that Darwin versions map to macOS versions.